### PR TITLE
Update/Refactor schedule generation scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,15 @@ dependencies = [
     "zipp>=3.19.1",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "gspread~=6.1",
     "oauth2client~=4.1",
     "pillow==10.4.0",
     "pytest~=8.0.0",
     "python-dotenv~=1.0",
-    "ruff~=0.6.5",
     "setuptools==74.1.2",
+]
+lint = [
+    "ruff~=0.6.5",
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,238 @@
+# TKD Registration Backend Scripts
+
+This README focuses on how to run and use the helper scripts in `scripts/`.
+
+## Prerequisites
+
+1. Python 3.11+
+2. `uv` installed
+3. AWS credentials configured locally (profile or environment variables)
+4. Environment variables set (via `.env` at repo root, exported vars, or env files)
+
+Install dependencies:
+
+```bash
+uv python install
+uv sync --all-extras --dev
+```
+
+## Running Scripts
+
+Run all scripts from the repository root.
+
+General pattern:
+
+```bash
+uv run python scripts/<script_name>.py [options]
+```
+
+## Shared Environment Variables
+
+Most scripts use one or more of the following:
+
+- `DB_TABLE`: DynamoDB registrations table name
+- `BADGE_IMG_FILENAME`: Source image filename under `img/` (used by `generate_all_badges.py`)
+- `BADGE_BUCKET`: S3 bucket containing/generated badges
+- `BADGE_GFOLDER`: Google Drive folder ID for badge sync
+- `CONFIG_BUCKET`: S3 bucket containing `tkd-reg_service_account.json`
+
+## Script Reference
+
+### `archive_reg_db.py`
+
+Exports competitor registration data from a DynamoDB table to a local JSON file. If the output file already exists, new records are merged into existing content by full name.
+
+Usage:
+
+```bash
+uv run python scripts/archive_reg_db.py [--profile AWS_PROFILE] [--output OUTPUT_FILE] TABLE_NAME
+```
+
+Examples:
+
+```bash
+uv run python scripts/archive_reg_db.py reg_lookup_table
+uv run python scripts/archive_reg_db.py --profile personal --output backups/full_lookup.json reg_lookup_table
+```
+
+### `load_lookup_db.py`
+
+Loads a previously exported lookup JSON file into a DynamoDB table with `put_item` per entry.
+
+Usage:
+
+```bash
+uv run python scripts/load_lookup_db.py [--profile AWS_PROFILE] [--table TABLE_NAME] INPUT_FILE
+```
+
+Examples:
+
+```bash
+uv run python scripts/load_lookup_db.py backups/full_lookup.json
+uv run python scripts/load_lookup_db.py --profile personal --table reg_lookup_table backups/full_lookup.json
+```
+
+### `generate_sparring_schedule.py`
+
+Builds sparring groups (2-4 competitors) from DynamoDB competitor entries and writes schedule files.
+
+Inputs:
+
+- Reads competitor data from `DB_TABLE`
+
+Outputs:
+
+- `output/sparring_groups.csv` (default)
+- Optional JSON: `output/sparring_groups.json`
+
+Usage:
+
+```bash
+uv run python scripts/generate_sparring_schedule.py [--output-format csv|json|both] [--output-dir DIR]
+```
+
+Examples:
+
+```bash
+uv run python scripts/generate_sparring_schedule.py
+uv run python scripts/generate_sparring_schedule.py --output-format both --output-dir output
+```
+
+### `generate_poomsae_schedule.py`
+
+Builds grouped poomsae schedule data (individual and world class), prints pair/team/family counts, and writes schedule files.
+
+Inputs:
+
+- Reads competitor data from `DB_TABLE`
+
+Outputs:
+
+- `output/poomsae_schedule_v2.csv` (default)
+- Optional JSON: `output/poomsae_schedule_v2.json`
+
+Usage:
+
+```bash
+uv run python scripts/generate_poomsae_schedule.py [--output-format csv|json|both] [--output-dir DIR]
+```
+
+Examples:
+
+```bash
+uv run python scripts/generate_poomsae_schedule.py
+uv run python scripts/generate_poomsae_schedule.py --output-format both --output-dir output
+```
+
+### `get_sparring_counts.py`
+
+Prints sparring participation totals and age/gender breakdowns for:
+
+- World Class (`sparring-wc`)
+- Grass Roots (`sparring-gr`)
+- Color Belt (`sparring`)
+- Combined Color Belt + Grass Roots
+
+Usage:
+
+```bash
+uv run python scripts/get_sparring_counts.py
+```
+
+### `get_poomsae_counts.py`
+
+Prints poomsae participation totals and age/gender breakdowns for:
+
+- World Class Poomsae
+- Individual Poomsae
+- Pair Poomsae
+- Team Poomsae
+
+Usage:
+
+```bash
+uv run python scripts/get_poomsae_counts.py
+```
+
+### `generate_all_badges.py`
+
+Generates all competitor badges from DynamoDB records and saves JPG files locally.
+
+Inputs:
+
+- `DB_TABLE`
+- `BADGE_IMG_FILENAME` (used from `img/<BADGE_IMG_FILENAME>`)
+
+Output:
+
+- `output/<pk>_badge.jpg`
+
+Usage:
+
+```bash
+uv run python scripts/generate_all_badges.py
+```
+
+### `generate_all_badges_okc.py`
+
+Generates all competitor badges using the OKC-specific layout and saves JPG files locally.
+
+Input:
+
+- `DB_TABLE`
+
+Output:
+
+- `output/<pk>_badge.jpg`
+
+Usage:
+
+```bash
+uv run python scripts/generate_all_badges_okc.py
+```
+
+### `regen_badges.py`
+
+Interactive utility to pick a competitor from DynamoDB, then optionally:
+
+- Regenerate badge
+- Resend confirmation email
+
+This script uses functions from `process_entries.py`.
+
+Input:
+
+- `DB_TABLE`
+
+Usage:
+
+```bash
+uv run python scripts/regen_badges.py
+```
+
+### `sync_aws_gdrive.py`
+
+Syncs badge images from S3 (`BADGE_BUCKET`) into a Google Drive folder (`BADGE_GFOLDER`). If a badge already exists in Drive with the same name, it is deleted first and then re-uploaded.
+
+Inputs:
+
+- `CONFIG_BUCKET` containing `tkd-reg_service_account.json`
+- `BADGE_BUCKET`
+- `BADGE_GFOLDER`
+
+Usage:
+
+```bash
+uv run python scripts/sync_aws_gdrive.py
+```
+
+## Troubleshooting
+
+- `botocore.exceptions.NoCredentialsError`:
+  - Configure AWS credentials/profile and confirm access to the target table/buckets.
+- Missing `DB_TABLE` or other env values:
+  - Ensure your `.env` or exported environment variables are loaded.
+- Google Drive auth failures in `sync_aws_gdrive.py`:
+  - Verify `CONFIG_BUCKET` has `tkd-reg_service_account.json` and that the service account has Drive access.
+- Missing image/font files during badge generation:
+  - Confirm required files exist under `img/` (for example, fonts and the image named by `BADGE_IMG_FILENAME`).

--- a/scripts/generate_poomsae_schedule.py
+++ b/scripts/generate_poomsae_schedule.py
@@ -84,6 +84,16 @@ def get_age_group(age: int) -> str:
     return next((group for group, ages in AGE_GROUPS.items() if age in ages), "ultra")
 
 
+def age_group_move_direction(original: str, current: str) -> str:
+    orig_idx = AGE_GROUP_ORDER.index(original)
+    curr_idx = AGE_GROUP_ORDER.index(current)
+    if curr_idx > orig_idx:
+        return "up"
+    if curr_idx < orig_idx:
+        return "down"
+    return ""
+
+
 def normalize_gender(gender: str) -> str:
     cleaned = (gender or "").strip().lower()
     if cleaned.startswith("m"):
@@ -396,7 +406,7 @@ def grouped_rows(groups: list[Group], division_label: str) -> list[dict]:
                     "age": competitor.age,
                     "age_group": competitor.age_group,
                     "original_age_group": competitor.original_age_group,
-                    "moved_up_age_group": competitor.original_age_group != competitor.age_group,
+                    "age_group_move_direction": age_group_move_direction(competitor.original_age_group, competitor.age_group),
                     "belt": competitor.belt,
                 }
             )
@@ -418,7 +428,7 @@ def list_rows(competitors: list[Competitor], division_label: str) -> list[dict]:
                 "age": competitor.age,
                 "age_group": competitor.age_group,
                 "original_age_group": competitor.original_age_group,
-                "moved_up_age_group": competitor.original_age_group != competitor.age_group,
+                "age_group_move_direction": age_group_move_direction(competitor.original_age_group, competitor.age_group),
                 "belt": competitor.belt,
                 "list_position": index,
             }
@@ -455,7 +465,7 @@ def write_csv(rows: list[dict], output_path: str) -> None:
         "age",
         "age_group",
         "original_age_group",
-        "moved_up_age_group",
+        "age_group_move_direction",
         "belt",
     ]
 

--- a/scripts/generate_poomsae_schedule.py
+++ b/scripts/generate_poomsae_schedule.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
-# import io
+import argparse
+import csv
+import json
+import math
 import os
+from dataclasses import dataclass, field
+
 import boto3
 from dotenv import load_dotenv
 
@@ -10,109 +15,520 @@ script_directory = os.path.dirname(script_path)
 parent_directory = os.path.dirname(script_directory)
 os.chdir(parent_directory)
 
+AGE_GROUP_ORDER = ["dragon", "tiger", "youth", "cadet", "junior", "senior", "ultra"]
+AGE_GROUPS = {
+    "dragon": [4, 5, 6, 7],
+    "tiger": [8, 9],
+    "youth": [10, 11],
+    "cadet": [12, 13, 14],
+    "junior": [15, 16],
+    "senior": list(range(17, 33)),
+    "ultra": list(range(33, 100)),
+}
 
-def get_entries():
+BELT_ORDER = ["yellow", "orange", "green", "blue", "red", "brown", "black"]
+BELT_ORDER_INDEX = {belt: index for index, belt in enumerate(BELT_ORDER)}
+
+
+@dataclass
+class Competitor:
+    name: str
+    school: str
+    gender: str
+    age: int
+    belt: str
+    belt_rank: int
+    division: str
+    age_group: str
+    original_age_group: str
+
+
+@dataclass
+class Group:
+    division: str
+    gender: str
+    age_group: str
+    members: list[Competitor] = field(default_factory=list)
+
+
+def get_entries() -> list[dict]:
     dynamodb = boto3.client("dynamodb")
     table_name = os.getenv("DB_TABLE")
     print(f"Getting entries from {table_name}")
-    items = dynamodb.scan(
-        TableName=table_name,
-        FilterExpression="reg_type = :competitor",
-        ExpressionAttributeValues={
-            ":competitor": {
-                "S": "competitor",
+
+    items = []
+    last_evaluated_key = None
+    while True:
+        kwargs = {
+            "TableName": table_name,
+            "FilterExpression": "reg_type = :competitor",
+            "ExpressionAttributeValues": {
+                ":competitor": {
+                    "S": "competitor",
+                },
             },
-        },
-    )["Items"]
+        }
+        if last_evaluated_key:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+
+        response = dynamodb.scan(**kwargs)
+        items.extend(response.get("Items", []))
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
     return items
 
 
-def get_age_group(entry):
-    age_groups = {
-        "dragon": [4, 5, 6, 7],
-        "tiger": [8, 9],
-        "youth": [10, 11],
-        "cadet": [12, 13, 14],
-        "junior": [15, 16],
-        "senior": list(range(17, 33)),
-        "ultra": list(range(33, 100)),
-    }
-
-    age_group = next((group for group, ages in age_groups.items() if int(entry["age"]["N"]) in ages))
-
-    return age_group
+def get_age_group(age: int) -> str:
+    return next((group for group, ages in AGE_GROUPS.items() if age in ages), "ultra")
 
 
-def divide_age_groups(entries):
-    dragon = [entry for entry in entries if get_age_group(entry) == 'dragon']
-    tiger = [entry for entry in entries if get_age_group(entry) == 'tiger']
-    youth = [entry for entry in entries if get_age_group(entry) == 'youth']
-    cadet = [entry for entry in entries if get_age_group(entry) == 'cadet']
-    junior = [entry for entry in entries if get_age_group(entry) == 'junior']
-    senior = [entry for entry in entries if get_age_group(entry) == 'senior']
-    ultra = [entry for entry in entries if get_age_group(entry) == 'ultra']
-    
-    return {
-        'dragon': dragon,
-        'tiger': tiger,
-        'youth': youth,
-        'cadet': cadet,
-        'junior': junior,
-        'senior': senior,
-        'ultra': ultra
-    }
+def normalize_gender(gender: str) -> str:
+    cleaned = (gender or "").strip().lower()
+    if cleaned.startswith("m"):
+        return "male"
+    if cleaned.startswith("f"):
+        return "female"
+    return "unknown"
 
 
+def normalize_belt(belt: str) -> str:
+    cleaned = (belt or "").strip().lower()
+    for expected in BELT_ORDER:
+        if expected in cleaned:
+            return expected
+    return cleaned or "unknown"
 
 
-def main():
+def belt_label(competitor: Competitor) -> str:
+    if competitor.belt in BELT_ORDER_INDEX:
+        # Human-friendly 1-based level aligns with event rules.
+        return f"{competitor.belt} (level {competitor.belt_rank + 1})"
+    return competitor.belt
+
+
+def parse_divisions(events: str) -> list[str]:
+    event_list = [event.strip().lower() for event in (events or "").split(",") if event.strip()]
+    divisions = []
+
+    if "poomsae" in event_list:
+        divisions.append("individual")
+    if "world-class poomsae" in event_list:
+        divisions.append("world_class")
+    if "pair poomsae" in event_list:
+        divisions.append("pair")
+    if "team poomsae" in event_list:
+        divisions.append("team")
+    if "family poomsae" in event_list:
+        divisions.append("family")
+
+    return divisions
+
+
+def parse_competitors(entries: list[dict]) -> list[Competitor]:
+    competitors = []
+    for entry in entries:
+        divisions = parse_divisions(entry.get("events", {}).get("S", ""))
+        if not divisions:
+            continue
+
+        age = int(entry.get("age", {}).get("N", 0))
+        age_group = get_age_group(age)
+        name = entry.get("full_name", {}).get("S", "Unknown Competitor")
+        school = entry.get("school", {}).get("S", "Unknown School")
+        gender = normalize_gender(entry.get("gender", {}).get("S", "unknown"))
+        belt = normalize_belt(entry.get("beltRank", {}).get("S", "unknown"))
+        belt_rank = BELT_ORDER_INDEX.get(belt, len(BELT_ORDER))
+
+        for division in divisions:
+            competitors.append(
+                Competitor(
+                    name=name,
+                    school=school,
+                    gender=gender,
+                    age=age,
+                    belt=belt,
+                    belt_rank=belt_rank,
+                    division=division,
+                    age_group=age_group,
+                    original_age_group=age_group,
+                )
+            )
+
+    return competitors
+
+
+def build_age_buckets(competitors: list[Competitor]) -> dict[str, list[Competitor]]:
+    buckets = {age_group: [] for age_group in AGE_GROUP_ORDER}
+    for competitor in competitors:
+        buckets[competitor.age_group].append(competitor)
+    return buckets
+
+
+def _age_bucket_score(count: int) -> int:
+    # Lower is better: 1-person age buckets are hardest to schedule.
+    if count == 1:
+        return 10
+    return 0
+
+
+def rebalance_singletons_adjacent(buckets: dict[str, list[Competitor]]) -> dict[str, list[Competitor]]:
+    """
+    Move single-competitor age buckets by one bracket only when it improves
+    bracket viability for 2-4 competitor groups. Prefer whichever adjacent move
+    yields the best improvement, with upward movement as the tie-breaker.
+    """
+    for index, age_group in enumerate(AGE_GROUP_ORDER):
+        if len(buckets[age_group]) != 1:
+            continue
+
+        source_count = len(buckets[age_group])
+        source_score_before = _age_bucket_score(source_count)
+
+        candidates = []
+        for delta in (1, -1):
+            neighbor_index = index + delta
+            if neighbor_index < 0 or neighbor_index >= len(AGE_GROUP_ORDER):
+                continue
+
+            neighbor_group = AGE_GROUP_ORDER[neighbor_index]
+            neighbor_count = len(buckets[neighbor_group])
+
+            source_score_after = _age_bucket_score(source_count - 1)
+            neighbor_score_before = _age_bucket_score(neighbor_count)
+            neighbor_score_after = _age_bucket_score(neighbor_count + 1)
+
+            before_total = source_score_before + neighbor_score_before
+            after_total = source_score_after + neighbor_score_after
+            improvement = before_total - after_total
+
+            if improvement > 0:
+                candidates.append((improvement, delta, neighbor_group))
+
+        if not candidates:
+            continue
+
+        # Higher improvement first; if equal, prefer moving up (delta=1).
+        candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        chosen_group = candidates[0][2]
+
+        moved = buckets[age_group].pop()
+        moved.age_group = chosen_group
+        buckets[chosen_group].append(moved)
+
+    return buckets
+
+
+def group_size_plan(count: int) -> list[int]:
+    if count <= 0:
+        return []
+    if count <= 4:
+        return [count]
+
+    group_count = math.ceil(count / 4)
+    sizes = [count // group_count] * group_count
+    for index in range(count % group_count):
+        sizes[index] += 1
+
+    return sizes
+
+
+def split_even_belt_groups(entries: list[Competitor]) -> list[list[Competitor]]:
+    entries = sorted(entries, key=lambda competitor: (competitor.belt_rank, competitor.name.lower()))
+    size_plan = group_size_plan(len(entries))
+    if not size_plan:
+        return []
+
+    groups = [[] for _ in size_plan]
+
+    def belt_fit_score(group: list[Competitor], competitor: Competitor) -> tuple[int, int]:
+        if not group:
+            # Prefer adding to a compatible existing belt cluster before opening a new one.
+            return (2, 0)
+
+        belt_values = [member.belt_rank for member in group]
+        min_belt = min(belt_values)
+        max_belt = max(belt_values)
+
+        if competitor.belt_rank < min_belt:
+            distance = min_belt - competitor.belt_rank
+        elif competitor.belt_rank > max_belt:
+            distance = competitor.belt_rank - max_belt
+        else:
+            distance = 0
+
+        new_min = min(min_belt, competitor.belt_rank)
+        new_max = max(max_belt, competitor.belt_rank)
+        new_range = new_max - new_min
+
+        return (distance, new_range)
+
+    for competitor in entries:
+        candidates = [index for index, group in enumerate(groups) if len(group) < size_plan[index]]
+        best_index = min(
+            candidates,
+            key=lambda index: (
+                belt_fit_score(groups[index], competitor),
+                sum(1 for member in groups[index] if member.school == competitor.school),
+                len(groups[index]),
+                index,
+            ),
+        )
+        groups[best_index].append(competitor)
+
+    return groups
+
+
+def generate_grouped_division(
+    competitors: list[Competitor],
+    division_name: str,
+) -> list[Group]:
+    groups = []
+    for gender in ["female", "male", "unknown"]:
+        division_entries = [
+            competitor
+            for competitor in competitors
+            if competitor.division == division_name and competitor.gender == gender
+        ]
+        if not division_entries:
+            continue
+
+        buckets = rebalance_singletons_adjacent(build_age_buckets(division_entries))
+        for age_group in AGE_GROUP_ORDER:
+            age_entries = buckets[age_group]
+            if not age_entries:
+                continue
+            split_groups = split_even_belt_groups(age_entries)
+            for members in split_groups:
+                groups.append(Group(division=division_name, gender=gender, age_group=age_group, members=members))
+
+    return groups
+
+
+def competitors_for_division(competitors: list[Competitor], division_name: str) -> list[Competitor]:
+    division_entries = [competitor for competitor in competitors if competitor.division == division_name]
+
+    gender_order = {"female": 0, "male": 1, "unknown": 2}
+    return sorted(
+        division_entries,
+        key=lambda competitor: (
+            AGE_GROUP_ORDER.index(competitor.age_group),
+            gender_order.get(competitor.gender, 99),
+            competitor.belt_rank,
+            competitor.name.lower(),
+        ),
+    )
+
+
+def print_grouped_division(title: str, groups: list[Group]) -> None:
+    print(f"{title} Groups (target size: 2-4 competitors)")
+    print("=" * 88)
+
+    if not groups:
+        print("No competitors found.\n")
+        return
+
+    gender_order = {"female": 0, "male": 1, "unknown": 2}
+    sorted_groups = sorted(
+        groups,
+        key=lambda group: (
+            gender_order.get(group.gender, 99),
+            AGE_GROUP_ORDER.index(group.age_group),
+            len(group.members),
+        ),
+    )
+
+    for index, group in enumerate(sorted_groups, start=1):
+        print(f"Group {index:02d} | gender={group.gender} | age={group.age_group} | size={len(group.members)}")
+
+        for competitor in sorted(group.members, key=lambda member: (member.belt_rank, member.name.lower())):
+            moved_tag = ""
+            if competitor.original_age_group != competitor.age_group:
+                moved_tag = f" (moved from {competitor.original_age_group})"
+            print(
+                f"  - {competitor.name} | {competitor.school} | age={competitor.age} | "
+                f"belt={belt_label(competitor)}{moved_tag}"
+            )
+
+        if len(group.members) < 2:
+            print("  ! Needs manual merge (single competitor group)")
+
+        schools = [competitor.school for competitor in group.members]
+        duplicates = {school for school in schools if schools.count(school) > 1}
+        if duplicates:
+            print(f"  ! Same-school pairing present: {', '.join(sorted(duplicates))}")
+
+        print()
+
+
+def print_counted_list(title: str, competitors: list[Competitor]) -> None:
+    print(f"{title} Competitors (count: {len(competitors)})")
+    print("=" * 88)
+
+    if not competitors:
+        print("No competitors found.\n")
+        return
+
+    for index, competitor in enumerate(competitors, start=1):
+        print(
+            f"{index:02d}. {competitor.name} | {competitor.school} | "
+            f"age={competitor.age} ({competitor.age_group}) | "
+            f"gender={competitor.gender} | belt={belt_label(competitor)}"
+        )
+
+    print()
+
+
+def grouped_rows(groups: list[Group], division_label: str) -> list[dict]:
+    rows = []
+    for group_index, group in enumerate(groups, start=1):
+        for competitor in sorted(group.members, key=lambda member: (member.belt_rank, member.name.lower())):
+            rows.append(
+                {
+                    "section": "grouped",
+                    "division": division_label,
+                    "group_number": group_index,
+                    "group_size": len(group.members),
+                    "name": competitor.name,
+                    "school": competitor.school,
+                    "gender": competitor.gender,
+                    "age": competitor.age,
+                    "age_group": competitor.age_group,
+                    "original_age_group": competitor.original_age_group,
+                    "moved_up_age_group": competitor.original_age_group != competitor.age_group,
+                    "belt": competitor.belt,
+                }
+            )
+    return rows
+
+
+def list_rows(competitors: list[Competitor], division_label: str) -> list[dict]:
+    rows = []
+    for index, competitor in enumerate(competitors, start=1):
+        rows.append(
+            {
+                "section": "list",
+                "division": division_label,
+                "group_number": "",
+                "group_size": "",
+                "name": competitor.name,
+                "school": competitor.school,
+                "gender": competitor.gender,
+                "age": competitor.age,
+                "age_group": competitor.age_group,
+                "original_age_group": competitor.original_age_group,
+                "moved_up_age_group": competitor.original_age_group != competitor.age_group,
+                "belt": competitor.belt,
+                "list_position": index,
+            }
+        )
+    return rows
+
+
+def report_rows(
+    individual_groups: list[Group],
+    world_class_groups: list[Group],
+    pair_list: list[Competitor],
+    team_list: list[Competitor],
+    family_list: list[Competitor],
+) -> list[dict]:
+    rows = []
+    rows.extend(grouped_rows(individual_groups, "individual"))
+    rows.extend(grouped_rows(world_class_groups, "world_class"))
+    rows.extend(list_rows(pair_list, "pair"))
+    rows.extend(list_rows(team_list, "team"))
+    rows.extend(list_rows(family_list, "family"))
+    return rows
+
+
+def write_csv(rows: list[dict], output_path: str) -> None:
+    fieldnames = [
+        "section",
+        "division",
+        "group_number",
+        "group_size",
+        "list_position",
+        "name",
+        "school",
+        "gender",
+        "age",
+        "age_group",
+        "original_age_group",
+        "moved_up_age_group",
+        "belt",
+    ]
+
+    with open(output_path, "w", newline="", encoding="utf-8") as file_handle:
+        writer = csv.DictWriter(file_handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(rows: list[dict], output_path: str) -> None:
+    with open(output_path, "w", encoding="utf-8") as file_handle:
+        json.dump(rows, file_handle, indent=2)
+
+
+def export_report(rows: list[dict], output_format: str, output_dir: str) -> list[str]:
+    os.makedirs(output_dir, exist_ok=True)
+    written_files = []
+
+    if output_format in {"csv", "both"}:
+        csv_path = os.path.join(output_dir, "poomsae_schedule_v2.csv")
+        write_csv(rows, csv_path)
+        written_files.append(csv_path)
+
+    if output_format in {"json", "both"}:
+        json_path = os.path.join(output_dir, "poomsae_schedule_v2.json")
+        write_json(rows, json_path)
+        written_files.append(json_path)
+
+    return written_files
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate grouped poomsae schedules with optional exports.")
+    parser.add_argument(
+        "--output-format",
+        choices=["csv", "json", "both"],
+        default="csv",
+        help="Output format for saved schedule data. Defaults to csv.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        help="Directory for generated schedule files. Defaults to output/.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
     load_dotenv()
-    age_groups = ['dragon', 'tiger', 'youth', 'cadet', 'junior', 'senior', 'ultra']
+
     entries = get_entries()
-    poomsae = [entry for entry in entries if 'poomsae' in entry['events']['S'].split(',')]
-    world_class_poomsae = [entry for entry in entries if 'world-class poomsae' in entry['events']['S'].split(',')]
-    pair_poomsae = [entry for entry in entries if 'pair poomsae' in entry['events']['S'].split(',')]
-    team_poomsae = [entry for entry in entries if 'team poomsae' in entry['events']['S'].split(',')]
-    poomsae_groups = divide_age_groups(poomsae)
-    world_class_poomsae_groups = divide_age_groups(world_class_poomsae)
-    pair_poomsae_groups = divide_age_groups(pair_poomsae)
-    team_poomsae_groups = divide_age_groups(team_poomsae)
+    competitors = parse_competitors(entries)
 
-    print(f"World Class (Total: {len(world_class_poomsae)})")
-    for ag in age_groups:
-        female = [entry for entry in world_class_poomsae_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in world_class_poomsae_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
+    individual_groups = generate_grouped_division(competitors, "individual")
+    world_class_groups = generate_grouped_division(competitors, "world_class")
 
-    print(f"Individual Poomsae (Total: {len(poomsae)})")
-    for ag in age_groups:
-        female = [entry for entry in poomsae_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in poomsae_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
+    print_grouped_division("Individual Poomsae", individual_groups)
+    print_grouped_division("World Class Poomsae", world_class_groups)
 
-    print(f"Pair Poomsae (Total: {len(pair_poomsae)})")
-    for ag in age_groups:
-        female = [entry for entry in pair_poomsae_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in pair_poomsae_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
+    pair_list = competitors_for_division(competitors, "pair")
+    team_list = competitors_for_division(competitors, "team")
+    family_list = competitors_for_division(competitors, "family")
 
-    print(f"Team Poomsae (Total: {len(team_poomsae)})")
-    for ag in age_groups:
-        female = [entry for entry in team_poomsae_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in team_poomsae_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
+    print_counted_list("Pair Poomsae", pair_list)
+    print_counted_list("Team Poomsae", team_list)
+    print_counted_list("Family Poomsae", family_list)
+
+    rows = report_rows(individual_groups, world_class_groups, pair_list, team_list, family_list)
+    written_files = export_report(rows, args.output_format, args.output_dir)
+    print("Saved schedule data to:")
+    for file_path in written_files:
+        print(f"  - {file_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_sparring_schedule.py
+++ b/scripts/generate_sparring_schedule.py
@@ -255,8 +255,10 @@ def split_by_weight_and_school(entries: list[Competitor]) -> list[list[Competito
 
 
 def should_combine_color_and_grass(color_entries: list[Competitor], grass_entries: list[Competitor]) -> bool:
+    # Only use the combined division label when both divisions have competitors
+    # and at least one side is too small to stand alone.
     if not color_entries or not grass_entries:
-        return True
+        return False
     if len(color_entries) < 2 or len(grass_entries) < 2:
         return True
     return False

--- a/scripts/generate_sparring_schedule.py
+++ b/scripts/generate_sparring_schedule.py
@@ -291,7 +291,7 @@ def generate_division_gender_age_groups(
 def generate_groups(competitors: list[Competitor]) -> list[Group]:
     groups = []
 
-    for gender in ["female", "male"]:
+    for gender in ["female", "male", "unknown"]:
         world_entries = [
             competitor
             for competitor in competitors
@@ -361,11 +361,13 @@ def print_groups(groups: list[Group]) -> None:
         "color_belt+grass_roots": 3,
     }
 
+    gender_order = {"female": 0, "male": 1, "unknown": 2}
+
     groups = sorted(
         groups,
         key=lambda group: (
             order.get(group.division, 99),
-            0 if group.gender == "female" else 1,
+            gender_order.get(group.gender, 99),
             AGE_GROUP_ORDER.index(group.age_group),
             len(group.members),
         ),

--- a/scripts/generate_sparring_schedule.py
+++ b/scripts/generate_sparring_schedule.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
-# import io
+import argparse
+import csv
+import json
+import math
 import os
+from dataclasses import dataclass, field
+
 import boto3
 from dotenv import load_dotenv
 
@@ -10,108 +15,487 @@ script_directory = os.path.dirname(script_path)
 parent_directory = os.path.dirname(script_directory)
 os.chdir(parent_directory)
 
-load_dotenv()
+AGE_GROUP_ORDER = ["dragon", "tiger", "youth", "cadet", "junior", "senior", "ultra"]
+AGE_GROUPS = {
+    "dragon": [4, 5, 6, 7],
+    "tiger": [8, 9],
+    "youth": [10, 11],
+    "cadet": [12, 13, 14],
+    "junior": [15, 16],
+    "senior": list(range(17, 33)),
+    "ultra": list(range(33, 100)),
+}
+
+
+@dataclass
+class Competitor:
+    name: str
+    school: str
+    gender: str
+    age: int
+    weight: float
+    division: str
+    age_group: str
+    original_age_group: str
+    raw: dict
+
+
+@dataclass
+class Group:
+    division: str
+    gender: str
+    age_group: str
+    members: list[Competitor] = field(default_factory=list)
 
 
 def get_entries():
     dynamodb = boto3.client("dynamodb")
     table_name = os.getenv("DB_TABLE")
     print(f"Getting entries from {table_name}")
-    items = dynamodb.scan(
-        TableName=table_name,
-        FilterExpression="reg_type = :competitor",
-        ExpressionAttributeValues={
-            ":competitor": {
-                "S": "competitor",
+
+    items = []
+    last_evaluated_key = None
+    while True:
+        kwargs = {
+            "TableName": table_name,
+            "FilterExpression": "reg_type = :competitor",
+            "ExpressionAttributeValues": {
+                ":competitor": {
+                    "S": "competitor",
+                },
             },
-        },
-    )["Items"]
+        }
+        if last_evaluated_key:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+
+        response = dynamodb.scan(**kwargs)
+        items.extend(response.get("Items", []))
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
     return items
 
 
-def get_age_group(entry):
-    age_groups = {
-        "dragon": [4, 5, 6, 7],
-        "tiger": [8, 9],
-        "youth": [10, 11],
-        "cadet": [12, 13, 14],
-        "junior": [15, 16],
-        "senior": list(range(17, 33)),
-        "ultra": list(range(33, 100)),
+def get_age_group(age: int) -> str:
+    return next((group for group, ages in AGE_GROUPS.items() if age in ages), "ultra")
+
+
+def normalize_gender(gender: str) -> str:
+    gender = (gender or "").strip().lower()
+    if gender.startswith("m"):
+        return "male"
+    if gender.startswith("f"):
+        return "female"
+    return "unknown"
+
+
+def parse_divisions(events: str) -> list[str]:
+    event_list = [event.strip() for event in events.split(",") if event.strip()]
+    divisions = []
+    if "sparring-wc" in event_list:
+        divisions.append("world_class")
+    if "sparring" in event_list:
+        divisions.append("color_belt")
+    if "sparring-gr" in event_list:
+        divisions.append("grass_roots")
+    return divisions
+
+
+def parse_competitors(entries: list[dict]) -> list[Competitor]:
+    competitors = []
+    for entry in entries:
+        divisions = parse_divisions(entry.get("events", {}).get("S", ""))
+        if not divisions:
+            continue
+
+        age = int(entry.get("age", {}).get("N", 0))
+        weight = float(entry.get("weight", {}).get("N", 0))
+        gender = normalize_gender(entry.get("gender", {}).get("S", "unknown"))
+        school = entry.get("school", {}).get("S", "Unknown School")
+        name = entry.get("full_name", {}).get("S", "Unknown Competitor")
+        age_group = get_age_group(age)
+
+        for division in divisions:
+            competitors.append(
+                Competitor(
+                    name=name,
+                    school=school,
+                    gender=gender,
+                    age=age,
+                    weight=weight,
+                    division=division,
+                    age_group=age_group,
+                    original_age_group=age_group,
+                    raw=entry,
+                )
+            )
+
+    return competitors
+
+
+def build_age_buckets(competitors: list[Competitor]) -> dict[str, list[Competitor]]:
+    buckets = {age_group: [] for age_group in AGE_GROUP_ORDER}
+    for competitor in competitors:
+        buckets[competitor.age_group].append(competitor)
+    return buckets
+
+
+def can_form_valid_groups(count: int) -> bool:
+    if count == 0:
+        return True
+    size_plan = group_size_plan(count)
+    return bool(size_plan) and min(size_plan) >= 2
+
+
+def choose_singleton_target(
+    buckets: dict[str, list[Competitor]],
+    source_index: int,
+) -> str | None:
+    source_age_group = AGE_GROUP_ORDER[source_index]
+    source_count = len(buckets[source_age_group])
+    if source_count != 1:
+        return None
+
+    candidate_indices = []
+    if source_index - 1 >= 0:
+        candidate_indices.append(source_index - 1)
+    if source_index + 1 < len(AGE_GROUP_ORDER):
+        candidate_indices.append(source_index + 1)
+
+    candidates = []
+    for candidate_index in candidate_indices:
+        candidate_age_group = AGE_GROUP_ORDER[candidate_index]
+        candidate_count = len(buckets[candidate_age_group])
+
+        # Moving into an empty bracket creates a new singleton and doesn't help.
+        if candidate_count == 0:
+            continue
+
+        before_invalid = int(not can_form_valid_groups(source_count)) + int(not can_form_valid_groups(candidate_count))
+        after_invalid = int(not can_form_valid_groups(0)) + int(not can_form_valid_groups(candidate_count + 1))
+
+        # Only move if this improves local grouping viability.
+        if after_invalid >= before_invalid:
+            continue
+
+        candidates.append(
+            (
+                abs((candidate_count + 1) - 3),
+                0 if candidate_index > source_index else 1,
+                candidate_age_group,
+            )
+        )
+
+    if not candidates:
+        return None
+
+    _, _, target_age_group = min(candidates)
+    return target_age_group
+
+
+def rebalance_singletons_adjacent(buckets: dict[str, list[Competitor]]) -> dict[str, list[Competitor]]:
+    # Re-check repeatedly because moving one competitor can enable another valid move.
+    changed = True
+    while changed:
+        changed = False
+        for index, age_group in enumerate(AGE_GROUP_ORDER):
+            if len(buckets[age_group]) != 1:
+                continue
+
+            target_age_group = choose_singleton_target(buckets, index)
+            if not target_age_group:
+                continue
+
+            competitor = buckets[age_group].pop()
+            competitor.age_group = target_age_group
+            buckets[target_age_group].append(competitor)
+            changed = True
+
+    return buckets
+
+
+def group_size_plan(count: int) -> list[int]:
+    if count <= 0:
+        return []
+    if count <= 4:
+        return [count]
+
+    groups = math.ceil(count / 4)
+    sizes = [count // groups] * groups
+
+    for index in range(count % groups):
+        sizes[index] += 1
+
+    return sizes
+
+
+def split_by_weight_and_school(entries: list[Competitor]) -> list[list[Competitor]]:
+    entries = sorted(entries, key=lambda competitor: competitor.weight)
+    size_plan = group_size_plan(len(entries))
+
+    if not size_plan:
+        return []
+
+    groups = [[] for _ in size_plan]
+    max_sizes = list(size_plan)
+
+    for competitor in entries:
+        candidates = [index for index, group in enumerate(groups) if len(group) < max_sizes[index]]
+        best_index = min(
+            candidates,
+            key=lambda index: (
+                sum(1 for member in groups[index] if member.school == competitor.school),
+                len(groups[index]),
+            ),
+        )
+        groups[best_index].append(competitor)
+
+    return groups
+
+
+def should_combine_color_and_grass(color_entries: list[Competitor], grass_entries: list[Competitor]) -> bool:
+    if not color_entries or not grass_entries:
+        return True
+    if len(color_entries) < 2 or len(grass_entries) < 2:
+        return True
+    return False
+
+
+def generate_division_gender_age_groups(
+    division_name: str,
+    gender: str,
+    buckets: dict[str, list[Competitor]],
+) -> list[Group]:
+    groups = []
+    for age_group in AGE_GROUP_ORDER:
+        entries = buckets[age_group]
+        if not entries:
+            continue
+
+        split_groups = split_by_weight_and_school(entries)
+        for members in split_groups:
+            groups.append(
+                Group(
+                    division=division_name,
+                    gender=gender,
+                    age_group=age_group,
+                    members=members,
+                )
+            )
+    return groups
+
+
+def generate_groups(competitors: list[Competitor]) -> list[Group]:
+    groups = []
+
+    for gender in ["female", "male"]:
+        world_entries = [
+            competitor
+            for competitor in competitors
+            if competitor.division == "world_class" and competitor.gender == gender
+        ]
+        world_buckets = rebalance_singletons_adjacent(build_age_buckets(world_entries))
+        groups.extend(generate_division_gender_age_groups("world_class", gender, world_buckets))
+
+        color_entries = [
+            competitor
+            for competitor in competitors
+            if competitor.division == "color_belt" and competitor.gender == gender
+        ]
+        grass_entries = [
+            competitor
+            for competitor in competitors
+            if competitor.division == "grass_roots" and competitor.gender == gender
+        ]
+
+        color_buckets = rebalance_singletons_adjacent(build_age_buckets(color_entries))
+        grass_buckets = rebalance_singletons_adjacent(build_age_buckets(grass_entries))
+
+        for age_group in AGE_GROUP_ORDER:
+            age_color = color_buckets[age_group]
+            age_grass = grass_buckets[age_group]
+
+            if should_combine_color_and_grass(age_color, age_grass):
+                combined = age_color + age_grass
+                split_groups = split_by_weight_and_school(combined)
+                for members in split_groups:
+                    groups.append(
+                        Group(
+                            division="color_belt+grass_roots",
+                            gender=gender,
+                            age_group=age_group,
+                            members=members,
+                        )
+                    )
+            else:
+                for members in split_by_weight_and_school(age_color):
+                    groups.append(
+                        Group(
+                            division="color_belt",
+                            gender=gender,
+                            age_group=age_group,
+                            members=members,
+                        )
+                    )
+                for members in split_by_weight_and_school(age_grass):
+                    groups.append(
+                        Group(
+                            division="grass_roots",
+                            gender=gender,
+                            age_group=age_group,
+                            members=members,
+                        )
+                    )
+
+    return groups
+
+
+def print_groups(groups: list[Group]) -> None:
+    order = {
+        "world_class": 0,
+        "color_belt": 1,
+        "grass_roots": 2,
+        "color_belt+grass_roots": 3,
     }
 
-    age_group = next((group for group, ages in age_groups.items() if int(entry["age"]["N"]) in ages))
+    groups = sorted(
+        groups,
+        key=lambda group: (
+            order.get(group.division, 99),
+            0 if group.gender == "female" else 1,
+            AGE_GROUP_ORDER.index(group.age_group),
+            len(group.members),
+        ),
+    )
 
-    return age_group
+    if not groups:
+        print("No sparring competitors found.")
+        return
+
+    print("Sparring Groups (target size: 2-4 competitors)")
+    print("=" * 80)
+
+    for index, group in enumerate(groups, start=1):
+        print(
+            f"Group {index:02d} | division={group.division} | gender={group.gender} | "
+            f"age={group.age_group} | size={len(group.members)}"
+        )
+
+        for member in sorted(group.members, key=lambda competitor: competitor.weight):
+            moved_tag = ""
+            if member.original_age_group != member.age_group:
+                moved_tag = f" (moved from {member.original_age_group})"
+            print(
+                f"  - {member.name} | {member.school} | age={member.age} | "
+                f"weight={member.weight:.1f}{moved_tag}"
+            )
+
+        if len(group.members) < 2:
+            print("  ! Needs manual merge (single competitor group)")
+
+        schools = [member.school for member in group.members]
+        duplicates = {school for school in schools if schools.count(school) > 1}
+        if duplicates:
+            print(f"  ! Same-school matchup present: {', '.join(sorted(duplicates))}")
+
+        print()
 
 
-def divide_age_groups(entries):
-    dragon = [entry for entry in entries if get_age_group(entry) == 'dragon']
-    tiger = [entry for entry in entries if get_age_group(entry) == 'tiger']
-    youth = [entry for entry in entries if get_age_group(entry) == 'youth']
-    cadet = [entry for entry in entries if get_age_group(entry) == 'cadet']
-    junior = [entry for entry in entries if get_age_group(entry) == 'junior']
-    senior = [entry for entry in entries if get_age_group(entry) == 'senior']
-    ultra = [entry for entry in entries if get_age_group(entry) == 'ultra']
-    
-    return {
-        'dragon': dragon,
-        'tiger': tiger,
-        'youth': youth,
-        'cadet': cadet,
-        'junior': junior,
-        'senior': senior,
-        'ultra': ultra
-    }
+def groups_to_rows(groups: list[Group]) -> list[dict]:
+    rows = []
+    for group_index, group in enumerate(groups, start=1):
+        for competitor in sorted(group.members, key=lambda member: member.weight):
+            rows.append(
+                {
+                    "group_number": group_index,
+                    "division": group.division,
+                    "gender": group.gender,
+                    "age_group": group.age_group,
+                    "group_size": len(group.members),
+                    "competitor_name": competitor.name,
+                    "school": competitor.school,
+                    "age": competitor.age,
+                    "weight": competitor.weight,
+                    "original_age_group": competitor.original_age_group,
+                    "moved_up_age_group": competitor.original_age_group != competitor.age_group,
+                }
+            )
+    return rows
 
 
+def write_csv(groups: list[Group], output_path: str) -> None:
+    rows = groups_to_rows(groups)
+    fieldnames = [
+        "group_number",
+        "division",
+        "gender",
+        "age_group",
+        "group_size",
+        "competitor_name",
+        "school",
+        "age",
+        "weight",
+        "original_age_group",
+        "moved_up_age_group",
+    ]
+
+    with open(output_path, "w", newline="", encoding="utf-8") as file_handle:
+        writer = csv.DictWriter(file_handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(groups: list[Group], output_path: str) -> None:
+    rows = groups_to_rows(groups)
+    with open(output_path, "w", encoding="utf-8") as file_handle:
+        json.dump(rows, file_handle, indent=2)
+
+
+def export_groups(groups: list[Group], output_format: str, output_dir: str = "output") -> list[str]:
+    os.makedirs(output_dir, exist_ok=True)
+    written_files = []
+
+    if output_format in {"csv", "both"}:
+        csv_path = os.path.join(output_dir, "sparring_groups.csv")
+        write_csv(groups, csv_path)
+        written_files.append(csv_path)
+
+    if output_format in {"json", "both"}:
+        json_path = os.path.join(output_dir, "sparring_groups.json")
+        write_json(groups, json_path)
+        written_files.append(json_path)
+
+    return written_files
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate 2-4 person sparring groups.")
+    parser.add_argument(
+        "--output-format",
+        choices=["csv", "json", "both"],
+        default="csv",
+        help="Output format for saved group data. Defaults to csv.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        help="Directory for generated schedule files. Defaults to output/.",
+    )
+    return parser.parse_args()
 
 
 def main():
-    age_groups = ['dragon', 'tiger', 'youth', 'cadet', 'junior', 'senior', 'ultra']
+    args = parse_args()
+    load_dotenv()
     entries = get_entries()
-    sparring = [entry for entry in entries if 'sparring' in entry['events']['S'].split(',')]
-    gr_sparring = [entry for entry in entries if 'sparring-gr' in entry['events']['S'].split(',')]
-    wc_sparring = [entry for entry in entries if 'sparring-wc' in entry['events']['S'].split(',')]
-    sparring_groups = divide_age_groups(sparring)
-    gr_sparring_groups = divide_age_groups(gr_sparring)
-    wc_sparring_groups = divide_age_groups(wc_sparring)
-
-    print(f"World Class (Total: {len(wc_sparring)})")
-    for ag in age_groups:
-        female = [entry for entry in wc_sparring_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in wc_sparring_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
-
-    print(f"Grass Roots (Total: {len(gr_sparring)})")
-    for ag in age_groups:
-        female = [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
-
-    print(f"Color Belts (Total: {len(sparring)})")
-    for ag in age_groups:
-        female = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
-
-    print(f"Color Belts + Grass Roots (Total: {len(sparring) + len(gr_sparring)})")
-    for ag in age_groups:
-        female = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'female'] + [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'female']
-        male = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'male'] + [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'male']
-        print(f"  {ag.capitalize()}")
-        print(f"    Female: {len(female)}")
-        print(f"      Male: {len(male)}")
-        print()
+    competitors = parse_competitors(entries)
+    groups = generate_groups(competitors)
+    print_groups(groups)
+    written_files = export_groups(groups, args.output_format, args.output_dir)
+    print("Saved group data to:")
+    for file_path in written_files:
+        print(f"  - {file_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_sparring_schedule.py
+++ b/scripts/generate_sparring_schedule.py
@@ -81,6 +81,16 @@ def get_age_group(age: int) -> str:
     return next((group for group, ages in AGE_GROUPS.items() if age in ages), "ultra")
 
 
+def age_group_move_direction(original: str, current: str) -> str:
+    orig_idx = AGE_GROUP_ORDER.index(original)
+    curr_idx = AGE_GROUP_ORDER.index(current)
+    if curr_idx > orig_idx:
+        return "up"
+    if curr_idx < orig_idx:
+        return "down"
+    return ""
+
+
 def normalize_gender(gender: str) -> str:
     gender = (gender or "").strip().lower()
     if gender.startswith("m"):
@@ -422,7 +432,7 @@ def groups_to_rows(groups: list[Group]) -> list[dict]:
                     "age": competitor.age,
                     "weight": competitor.weight,
                     "original_age_group": competitor.original_age_group,
-                    "moved_up_age_group": competitor.original_age_group != competitor.age_group,
+                    "age_group_move_direction": age_group_move_direction(competitor.original_age_group, competitor.age_group),
                 }
             )
     return rows
@@ -441,7 +451,7 @@ def write_csv(groups: list[Group], output_path: str) -> None:
         "age",
         "weight",
         "original_age_group",
-        "moved_up_age_group",
+        "age_group_move_direction",
     ]
 
     with open(output_path, "w", newline="", encoding="utf-8") as file_handle:

--- a/scripts/get_poomsae_counts.py
+++ b/scripts/get_poomsae_counts.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+# import io
+import os
+import boto3
+from dotenv import load_dotenv
+
+script_path = os.path.abspath(__file__)
+script_directory = os.path.dirname(script_path)
+parent_directory = os.path.dirname(script_directory)
+os.chdir(parent_directory)
+
+
+def get_entries():
+    dynamodb = boto3.client("dynamodb")
+    table_name = os.getenv("DB_TABLE")
+    print(f"Getting entries from {table_name}")
+    items = dynamodb.scan(
+        TableName=table_name,
+        FilterExpression="reg_type = :competitor",
+        ExpressionAttributeValues={
+            ":competitor": {
+                "S": "competitor",
+            },
+        },
+    )["Items"]
+    return items
+
+
+def get_age_group(entry):
+    age_groups = {
+        "dragon": [4, 5, 6, 7],
+        "tiger": [8, 9],
+        "youth": [10, 11],
+        "cadet": [12, 13, 14],
+        "junior": [15, 16],
+        "senior": list(range(17, 33)),
+        "ultra": list(range(33, 100)),
+    }
+
+    age_group = next((group for group, ages in age_groups.items() if int(entry["age"]["N"]) in ages))
+
+    return age_group
+
+
+def divide_age_groups(entries):
+    dragon = [entry for entry in entries if get_age_group(entry) == 'dragon']
+    tiger = [entry for entry in entries if get_age_group(entry) == 'tiger']
+    youth = [entry for entry in entries if get_age_group(entry) == 'youth']
+    cadet = [entry for entry in entries if get_age_group(entry) == 'cadet']
+    junior = [entry for entry in entries if get_age_group(entry) == 'junior']
+    senior = [entry for entry in entries if get_age_group(entry) == 'senior']
+    ultra = [entry for entry in entries if get_age_group(entry) == 'ultra']
+    
+    return {
+        'dragon': dragon,
+        'tiger': tiger,
+        'youth': youth,
+        'cadet': cadet,
+        'junior': junior,
+        'senior': senior,
+        'ultra': ultra
+    }
+
+
+
+
+def main():
+    load_dotenv()
+    age_groups = ['dragon', 'tiger', 'youth', 'cadet', 'junior', 'senior', 'ultra']
+    entries = get_entries()
+    poomsae = [entry for entry in entries if 'poomsae' in entry['events']['S'].split(',')]
+    world_class_poomsae = [entry for entry in entries if 'world-class poomsae' in entry['events']['S'].split(',')]
+    pair_poomsae = [entry for entry in entries if 'pair poomsae' in entry['events']['S'].split(',')]
+    team_poomsae = [entry for entry in entries if 'team poomsae' in entry['events']['S'].split(',')]
+    poomsae_groups = divide_age_groups(poomsae)
+    world_class_poomsae_groups = divide_age_groups(world_class_poomsae)
+    pair_poomsae_groups = divide_age_groups(pair_poomsae)
+    team_poomsae_groups = divide_age_groups(team_poomsae)
+
+    print(f"World Class (Total: {len(world_class_poomsae)})")
+    for ag in age_groups:
+        female = [entry for entry in world_class_poomsae_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in world_class_poomsae_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+    print(f"Individual Poomsae (Total: {len(poomsae)})")
+    for ag in age_groups:
+        female = [entry for entry in poomsae_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in poomsae_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+    print(f"Pair Poomsae (Total: {len(pair_poomsae)})")
+    for ag in age_groups:
+        female = [entry for entry in pair_poomsae_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in pair_poomsae_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+    print(f"Team Poomsae (Total: {len(team_poomsae)})")
+    for ag in age_groups:
+        female = [entry for entry in team_poomsae_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in team_poomsae_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_poomsae_counts.py
+++ b/scripts/get_poomsae_counts.py
@@ -49,8 +49,21 @@ def get_age_group(entry):
         "ultra": list(range(33, 100)),
     }
 
-    age_group = next((group for group, ages in age_groups.items() if int(entry["age"]["N"]) in ages))
+    # Safely parse the age field; if it's missing or invalid, skip this entry.
+    try:
+        age_value = int(entry.get("age", {}).get("N"))
+    except (TypeError, ValueError, AttributeError):
+        print(f"Skipping entry with invalid or missing age: {entry}")
+        return None
 
+    # Use a default with next() so that out-of-range ages don't raise StopIteration.
+    age_group = next(
+        (group for group, ages in age_groups.items() if age_value in ages),
+        None,
+    )
+
+    if age_group is None:
+        print(f"Skipping entry with out-of-range age {age_value}: {entry}")
     return age_group
 
 

--- a/scripts/get_poomsae_counts.py
+++ b/scripts/get_poomsae_counts.py
@@ -15,15 +15,26 @@ def get_entries():
     dynamodb = boto3.client("dynamodb")
     table_name = os.getenv("DB_TABLE")
     print(f"Getting entries from {table_name}")
-    items = dynamodb.scan(
-        TableName=table_name,
-        FilterExpression="reg_type = :competitor",
-        ExpressionAttributeValues={
+    items = []
+    scan_kwargs = {
+        "TableName": table_name,
+        "FilterExpression": "reg_type = :competitor",
+        "ExpressionAttributeValues": {
             ":competitor": {
                 "S": "competitor",
             },
         },
-    )["Items"]
+    }
+
+    while True:
+        response = dynamodb.scan(**scan_kwargs)
+        items.extend(response.get("Items", []))
+
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
+        scan_kwargs["ExclusiveStartKey"] = last_evaluated_key
     return items
 
 

--- a/scripts/get_sparring_counts.py
+++ b/scripts/get_sparring_counts.py
@@ -17,15 +17,22 @@ def get_entries():
     dynamodb = boto3.client("dynamodb")
     table_name = os.getenv("DB_TABLE")
     print(f"Getting entries from {table_name}")
-    items = dynamodb.scan(
-        TableName=table_name,
-        FilterExpression="reg_type = :competitor",
-        ExpressionAttributeValues={
+    items: list[dict] = []
+    scan_kwargs = {
+        "TableName": table_name,
+        "FilterExpression": "reg_type = :competitor",
+        "ExpressionAttributeValues": {
             ":competitor": {
                 "S": "competitor",
             },
         },
-    )["Items"]
+    }
+    response = dynamodb.scan(**scan_kwargs)
+    items.extend(response.get("Items", []))
+    while "LastEvaluatedKey" in response:
+        scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+        response = dynamodb.scan(**scan_kwargs)
+        items.extend(response.get("Items", []))
     return items
 
 

--- a/scripts/get_sparring_counts.py
+++ b/scripts/get_sparring_counts.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+# import io
+import os
+import boto3
+from dotenv import load_dotenv
+
+script_path = os.path.abspath(__file__)
+script_directory = os.path.dirname(script_path)
+parent_directory = os.path.dirname(script_directory)
+os.chdir(parent_directory)
+
+load_dotenv()
+
+
+def get_entries():
+    dynamodb = boto3.client("dynamodb")
+    table_name = os.getenv("DB_TABLE")
+    print(f"Getting entries from {table_name}")
+    items = dynamodb.scan(
+        TableName=table_name,
+        FilterExpression="reg_type = :competitor",
+        ExpressionAttributeValues={
+            ":competitor": {
+                "S": "competitor",
+            },
+        },
+    )["Items"]
+    return items
+
+
+def get_age_group(entry):
+    age_groups = {
+        "dragon": [4, 5, 6, 7],
+        "tiger": [8, 9],
+        "youth": [10, 11],
+        "cadet": [12, 13, 14],
+        "junior": [15, 16],
+        "senior": list(range(17, 33)),
+        "ultra": list(range(33, 100)),
+    }
+
+    age_group = next((group for group, ages in age_groups.items() if int(entry["age"]["N"]) in ages))
+
+    return age_group
+
+
+def divide_age_groups(entries):
+    dragon = [entry for entry in entries if get_age_group(entry) == 'dragon']
+    tiger = [entry for entry in entries if get_age_group(entry) == 'tiger']
+    youth = [entry for entry in entries if get_age_group(entry) == 'youth']
+    cadet = [entry for entry in entries if get_age_group(entry) == 'cadet']
+    junior = [entry for entry in entries if get_age_group(entry) == 'junior']
+    senior = [entry for entry in entries if get_age_group(entry) == 'senior']
+    ultra = [entry for entry in entries if get_age_group(entry) == 'ultra']
+    
+    return {
+        'dragon': dragon,
+        'tiger': tiger,
+        'youth': youth,
+        'cadet': cadet,
+        'junior': junior,
+        'senior': senior,
+        'ultra': ultra
+    }
+
+
+
+
+def main():
+    age_groups = ['dragon', 'tiger', 'youth', 'cadet', 'junior', 'senior', 'ultra']
+    entries = get_entries()
+    sparring = [entry for entry in entries if 'sparring' in entry['events']['S'].split(',')]
+    gr_sparring = [entry for entry in entries if 'sparring-gr' in entry['events']['S'].split(',')]
+    wc_sparring = [entry for entry in entries if 'sparring-wc' in entry['events']['S'].split(',')]
+    sparring_groups = divide_age_groups(sparring)
+    gr_sparring_groups = divide_age_groups(gr_sparring)
+    wc_sparring_groups = divide_age_groups(wc_sparring)
+
+    print(f"World Class (Total: {len(wc_sparring)})")
+    for ag in age_groups:
+        female = [entry for entry in wc_sparring_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in wc_sparring_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+    print(f"Grass Roots (Total: {len(gr_sparring)})")
+    for ag in age_groups:
+        female = [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+    print(f"Color Belts (Total: {len(sparring)})")
+    for ag in age_groups:
+        female = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+    print(f"Color Belts + Grass Roots (Total: {len(sparring) + len(gr_sparring)})")
+    for ag in age_groups:
+        female = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'female'] + [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'female']
+        male = [entry for entry in sparring_groups[ag] if entry['gender']['S'] == 'male'] + [entry for entry in gr_sparring_groups[ag] if entry['gender']['S'] == 'male']
+        print(f"  {ag.capitalize()}")
+        print(f"    Female: {len(female)}")
+        print(f"      Male: {len(male)}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_sparring_counts.py
+++ b/scripts/get_sparring_counts.py
@@ -47,8 +47,16 @@ def get_age_group(entry):
         "ultra": list(range(33, 100)),
     }
 
-    age_group = next((group for group, ages in age_groups.items() if int(entry["age"]["N"]) in ages))
+    try:
+        age = int(entry["age"]["N"])
+    except (KeyError, TypeError, ValueError):
+        # Invalid or missing age; signal no age group
+        return None
 
+    age_group = next(
+        (group for group, ages in age_groups.items() if age in ages),
+        None,
+    )
     return age_group
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,14 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
 name = "argcomplete"
 version = "3.5.1"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz", hash = "sha256:eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4", size = 82280 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz", hash = "sha256:eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4", size = 82280, upload-time = "2024-10-07T04:00:39.242Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f7/be/a606a6701d491cfae75583c80a6583f8abe9c36c0b9666e867e7cdd62fe8/argcomplete-3.5.1-py3-none-any.whl", hash = "sha256:1a1d148bdaa3e3b93454900163403df41448a248af01b6e849edc5ac08e6c363", size = 43498 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f7/be/a606a6701d491cfae75583c80a6583f8abe9c36c0b9666e867e7cdd62fe8/argcomplete-3.5.1-py3-none-any.whl", hash = "sha256:1a1d148bdaa3e3b93454900163403df41448a248af01b6e849edc5ac08e6c363", size = 43498, upload-time = "2024-10-07T04:00:36.986Z" },
 ]
 
 [[package]]
@@ -20,9 +20,9 @@ dependencies = [
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/29/4c/32228505d008de09740e778cc3f593d187b831dd6334d24d9bca1924ee7e/boto3-1.35.47.tar.gz", hash = "sha256:65b808e4cf1af8c2f405382d53656a0d92eee8f85c7388c43d64c7a5571b065f", size = 110991 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/29/4c/32228505d008de09740e778cc3f593d187b831dd6334d24d9bca1924ee7e/boto3-1.35.47.tar.gz", hash = "sha256:65b808e4cf1af8c2f405382d53656a0d92eee8f85c7388c43d64c7a5571b065f", size = 110991, upload-time = "2024-10-23T19:30:30.763Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2f/1b/55feb889aeff20f7f3333c03a82904ed0a0612e710f40293c572425f6196/boto3-1.35.47-py3-none-any.whl", hash = "sha256:0b307f685875e9c7857ce21c0d3050d8d4f3778455a6852d5f98ac75194b400e", size = 139161 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2f/1b/55feb889aeff20f7f3333c03a82904ed0a0612e710f40293c572425f6196/boto3-1.35.47-py3-none-any.whl", hash = "sha256:0b307f685875e9c7857ce21c0d3050d8d4f3778455a6852d5f98ac75194b400e", size = 139161, upload-time = "2024-10-23T19:30:28.115Z" },
 ]
 
 [[package]]
@@ -34,27 +34,27 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0e/02/eff8e5372c9659fb61721d14d17473e890d7d1a7a1762470d9963d7f8fbf/botocore-1.35.47.tar.gz", hash = "sha256:f8f703463d3cd8b6abe2bedc443a7ab29f0e2ff1588a2e83164b108748645547", size = 12849837 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0e/02/eff8e5372c9659fb61721d14d17473e890d7d1a7a1762470d9963d7f8fbf/botocore-1.35.47.tar.gz", hash = "sha256:f8f703463d3cd8b6abe2bedc443a7ab29f0e2ff1588a2e83164b108748645547", size = 12849837, upload-time = "2024-10-23T19:30:18.703Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2a/1b/d244f4a3d631f3535089c08a15737c7f9f11bb766120a6a196319e55b1f5/botocore-1.35.47-py3-none-any.whl", hash = "sha256:05f4493119a96799ff84d43e78691efac3177e1aec8840cca99511de940e342a", size = 12636917 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2a/1b/d244f4a3d631f3535089c08a15737c7f9f11bb766120a6a196319e55b1f5/botocore-1.35.47-py3-none-any.whl", hash = "sha256:05f4493119a96799ff84d43e78691efac3177e1aec8840cca99511de940e342a", size = 12636917, upload-time = "2024-10-23T19:30:14.212Z" },
 ]
 
 [[package]]
 name = "cachetools"
 version = "5.5.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661, upload-time = "2024-08-18T20:28:44.639Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524, upload-time = "2024-08-18T20:28:43.404Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2024.8.30"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload-time = "2024-08-30T01:55:04.365Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload-time = "2024-08-30T01:55:02.591Z" },
 ]
 
 [[package]]
@@ -66,63 +66,63 @@ dependencies = [
     { name = "pyyaml" },
     { name = "six" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ca/75/8eba0bb52a6c58e347bc4c839b249d9f42380de93ed12a14eba4355387b4/cfn_flip-1.3.0.tar.gz", hash = "sha256:003e02a089c35e1230ffd0e1bcfbbc4b12cc7d2deb2fcc6c4228ac9819307362", size = 16113 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ca/75/8eba0bb52a6c58e347bc4c839b249d9f42380de93ed12a14eba4355387b4/cfn_flip-1.3.0.tar.gz", hash = "sha256:003e02a089c35e1230ffd0e1bcfbbc4b12cc7d2deb2fcc6c4228ac9819307362", size = 16113, upload-time = "2021-10-07T10:05:14.956Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/a8/a67297cd63ef99c3391c1d143161b187b71afa715a988655758269e3d02f/cfn_flip-1.3.0-py3-none-any.whl", hash = "sha256:faca8e77f0d32fb84cce1db1ef4c18b14a325d31125dae73c13bcc01947d2722", size = 21387 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/a8/a67297cd63ef99c3391c1d143161b187b71afa715a988655758269e3d02f/cfn_flip-1.3.0-py3-none-any.whl", hash = "sha256:faca8e77f0d32fb84cce1db1ef4c18b14a325d31125dae73c13bcc01947d2722", size = 21387, upload-time = "2021-10-07T10:05:13.378Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz", hash = "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e", size = 106620 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz", hash = "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e", size = 106620, upload-time = "2024-10-09T07:40:20.413Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c", size = 193339 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944", size = 124366 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee", size = 118874 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c", size = 138243 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6", size = 148676 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea", size = 141289 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc", size = 142585 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3b/a0/a68980ab8a1f45a36d9745d35049c1af57d27255eff8c907e3add84cf68f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5", size = 144408 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594", size = 139076 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fb/9d/9c13753a5a6e0db4a0a6edb1cef7aee39859177b64e1a1e748a6e3ba62c2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c", size = 146874 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365", size = 150871 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129", size = 148546 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236", size = 143048 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/01/f8/38842422988b795220eb8038745d27a675ce066e2ada79516c118f291f07/charset_normalizer-3.4.0-cp311-cp311-win32.whl", hash = "sha256:9ae4ef0b3f6b41bad6366fb0ea4fc1d7ed051528e113a60fa2a65a9abb5b1d99", size = 94389 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27", size = 101752 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d3/0b/4b7a70987abf9b8196845806198975b6aab4ce016632f817ad758a5aa056/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6", size = 194445 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/50/89/354cc56cf4dd2449715bc9a0f54f3aef3dc700d2d62d1fa5bbea53b13426/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf", size = 125275 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fa/44/b730e2a2580110ced837ac083d8ad222343c96bb6b66e9e4e706e4d0b6df/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db", size = 119020 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9d/e4/9263b8240ed9472a2ae7ddc3e516e71ef46617fe40eaa51221ccd4ad9a27/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1", size = 139128 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6b/e3/9f73e779315a54334240353eaea75854a9a690f3f580e4bd85d977cb2204/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03", size = 149277 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1a/cf/f1f50c2f295312edb8a548d3fa56a5c923b146cd3f24114d5adb7e7be558/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284", size = 142174 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15", size = 143838 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a4/01/2117ff2b1dfc61695daf2babe4a874bca328489afa85952440b59819e9d7/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8", size = 146149 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f6/9b/93a332b8d25b347f6839ca0a61b7f0287b0930216994e8bf67a75d050255/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2", size = 140043 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ab/f6/7ac4a01adcdecbc7a7587767c776d53d369b8b971382b91211489535acf0/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719", size = 148229 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9d/be/5708ad18161dee7dc6a0f7e6cf3a88ea6279c3e8484844c0590e50e803ef/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631", size = 151556 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5a/bb/3d8bc22bacb9eb89785e83e6723f9888265f3a0de3b9ce724d66bd49884e/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b", size = 149772 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f7/fa/d3fc622de05a86f30beea5fc4e9ac46aead4731e73fd9055496732bcc0a4/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565", size = 144800 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9a/65/bdb9bc496d7d190d725e96816e20e2ae3a6fa42a5cac99c3c3d6ff884118/charset_normalizer-3.4.0-cp312-cp312-win32.whl", hash = "sha256:5726cf76c982532c1863fb64d8c6dd0e4c90b6ece9feb06c9f202417a31f7dd7", size = 94836 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3e/67/7b72b69d25b89c0b3cea583ee372c43aa24df15f0e0f8d3982c57804984b/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:b197e7094f232959f8f20541ead1d9862ac5ebea1d58e9849c1bf979255dfac9", size = 102187 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f3/89/68a4c86f1a0002810a27f12e9a7b22feb198c59b2f05231349fbce5c06f4/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114", size = 194617 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4f/cd/8947fe425e2ab0aa57aceb7807af13a0e4162cd21eee42ef5b053447edf5/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed", size = 125310 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5b/f0/b5263e8668a4ee9becc2b451ed909e9c27058337fda5b8c49588183c267a/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250", size = 119126 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ff/6e/e445afe4f7fda27a533f3234b627b3e515a1b9429bc981c9a5e2aa5d97b6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920", size = 139342 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a1/b2/4af9993b532d93270538ad4926c8e37dc29f2111c36f9c629840c57cd9b3/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64", size = 149383 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fb/6f/4e78c3b97686b871db9be6f31d64e9264e889f8c9d7ab33c771f847f79b7/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23", size = 142214 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/c9/1c8fe3ce05d30c87eff498592c89015b19fade13df42850aafae09e94f35/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc", size = 144104 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/68/efad5dcb306bf37db7db338338e7bb8ebd8cf38ee5bbd5ceaaaa46f257e6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d", size = 146255 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/75/1ed813c3ffd200b1f3e71121c95da3f79e6d2a96120163443b3ad1057505/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88", size = 140251 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7d/0d/6f32255c1979653b448d3c709583557a4d24ff97ac4f3a5be156b2e6a210/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90", size = 148474 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ac/a0/c1b5298de4670d997101fef95b97ac440e8c8d8b4efa5a4d1ef44af82f0d/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b", size = 151849 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/04/4f/b3961ba0c664989ba63e30595a3ed0875d6790ff26671e2aae2fdc28a399/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d", size = 149781 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d8/90/6af4cd042066a4adad58ae25648a12c09c879efa4849c705719ba1b23d8c/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482", size = 144970 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cc/67/e5e7e0cbfefc4ca79025238b43cdf8a2037854195b37d6417f3d0895c4c2/charset_normalizer-3.4.0-cp313-cp313-win32.whl", hash = "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67", size = 94973 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/65/97/fc9bbc54ee13d33dc54a7fcf17b26368b18505500fc01e228c27b5222d80/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b", size = 102308 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl", hash = "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079", size = 49446 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c", size = 193339, upload-time = "2024-10-09T07:38:24.527Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944", size = 124366, upload-time = "2024-10-09T07:38:26.488Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee", size = 118874, upload-time = "2024-10-09T07:38:28.115Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c", size = 138243, upload-time = "2024-10-09T07:38:29.822Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6", size = 148676, upload-time = "2024-10-09T07:38:30.869Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea", size = 141289, upload-time = "2024-10-09T07:38:32.557Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc", size = 142585, upload-time = "2024-10-09T07:38:33.649Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3b/a0/a68980ab8a1f45a36d9745d35049c1af57d27255eff8c907e3add84cf68f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5", size = 144408, upload-time = "2024-10-09T07:38:34.687Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594", size = 139076, upload-time = "2024-10-09T07:38:36.417Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fb/9d/9c13753a5a6e0db4a0a6edb1cef7aee39859177b64e1a1e748a6e3ba62c2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c", size = 146874, upload-time = "2024-10-09T07:38:37.59Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365", size = 150871, upload-time = "2024-10-09T07:38:38.666Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129", size = 148546, upload-time = "2024-10-09T07:38:40.459Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236", size = 143048, upload-time = "2024-10-09T07:38:42.178Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/01/f8/38842422988b795220eb8038745d27a675ce066e2ada79516c118f291f07/charset_normalizer-3.4.0-cp311-cp311-win32.whl", hash = "sha256:9ae4ef0b3f6b41bad6366fb0ea4fc1d7ed051528e113a60fa2a65a9abb5b1d99", size = 94389, upload-time = "2024-10-09T07:38:43.339Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27", size = 101752, upload-time = "2024-10-09T07:38:44.276Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d3/0b/4b7a70987abf9b8196845806198975b6aab4ce016632f817ad758a5aa056/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6", size = 194445, upload-time = "2024-10-09T07:38:45.275Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/50/89/354cc56cf4dd2449715bc9a0f54f3aef3dc700d2d62d1fa5bbea53b13426/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf", size = 125275, upload-time = "2024-10-09T07:38:46.449Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fa/44/b730e2a2580110ced837ac083d8ad222343c96bb6b66e9e4e706e4d0b6df/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db", size = 119020, upload-time = "2024-10-09T07:38:48.88Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9d/e4/9263b8240ed9472a2ae7ddc3e516e71ef46617fe40eaa51221ccd4ad9a27/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1", size = 139128, upload-time = "2024-10-09T07:38:49.86Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6b/e3/9f73e779315a54334240353eaea75854a9a690f3f580e4bd85d977cb2204/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03", size = 149277, upload-time = "2024-10-09T07:38:52.306Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1a/cf/f1f50c2f295312edb8a548d3fa56a5c923b146cd3f24114d5adb7e7be558/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284", size = 142174, upload-time = "2024-10-09T07:38:53.458Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15", size = 143838, upload-time = "2024-10-09T07:38:54.691Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a4/01/2117ff2b1dfc61695daf2babe4a874bca328489afa85952440b59819e9d7/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8", size = 146149, upload-time = "2024-10-09T07:38:55.737Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f6/9b/93a332b8d25b347f6839ca0a61b7f0287b0930216994e8bf67a75d050255/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2", size = 140043, upload-time = "2024-10-09T07:38:57.44Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ab/f6/7ac4a01adcdecbc7a7587767c776d53d369b8b971382b91211489535acf0/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719", size = 148229, upload-time = "2024-10-09T07:38:58.782Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9d/be/5708ad18161dee7dc6a0f7e6cf3a88ea6279c3e8484844c0590e50e803ef/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631", size = 151556, upload-time = "2024-10-09T07:39:00.467Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5a/bb/3d8bc22bacb9eb89785e83e6723f9888265f3a0de3b9ce724d66bd49884e/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b", size = 149772, upload-time = "2024-10-09T07:39:01.5Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f7/fa/d3fc622de05a86f30beea5fc4e9ac46aead4731e73fd9055496732bcc0a4/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565", size = 144800, upload-time = "2024-10-09T07:39:02.491Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9a/65/bdb9bc496d7d190d725e96816e20e2ae3a6fa42a5cac99c3c3d6ff884118/charset_normalizer-3.4.0-cp312-cp312-win32.whl", hash = "sha256:5726cf76c982532c1863fb64d8c6dd0e4c90b6ece9feb06c9f202417a31f7dd7", size = 94836, upload-time = "2024-10-09T07:39:04.607Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3e/67/7b72b69d25b89c0b3cea583ee372c43aa24df15f0e0f8d3982c57804984b/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:b197e7094f232959f8f20541ead1d9862ac5ebea1d58e9849c1bf979255dfac9", size = 102187, upload-time = "2024-10-09T07:39:06.247Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f3/89/68a4c86f1a0002810a27f12e9a7b22feb198c59b2f05231349fbce5c06f4/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114", size = 194617, upload-time = "2024-10-09T07:39:07.317Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4f/cd/8947fe425e2ab0aa57aceb7807af13a0e4162cd21eee42ef5b053447edf5/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed", size = 125310, upload-time = "2024-10-09T07:39:08.353Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5b/f0/b5263e8668a4ee9becc2b451ed909e9c27058337fda5b8c49588183c267a/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250", size = 119126, upload-time = "2024-10-09T07:39:09.327Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ff/6e/e445afe4f7fda27a533f3234b627b3e515a1b9429bc981c9a5e2aa5d97b6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920", size = 139342, upload-time = "2024-10-09T07:39:10.322Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a1/b2/4af9993b532d93270538ad4926c8e37dc29f2111c36f9c629840c57cd9b3/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64", size = 149383, upload-time = "2024-10-09T07:39:12.042Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fb/6f/4e78c3b97686b871db9be6f31d64e9264e889f8c9d7ab33c771f847f79b7/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23", size = 142214, upload-time = "2024-10-09T07:39:13.059Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/c9/1c8fe3ce05d30c87eff498592c89015b19fade13df42850aafae09e94f35/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc", size = 144104, upload-time = "2024-10-09T07:39:14.815Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/68/efad5dcb306bf37db7db338338e7bb8ebd8cf38ee5bbd5ceaaaa46f257e6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d", size = 146255, upload-time = "2024-10-09T07:39:15.868Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/75/1ed813c3ffd200b1f3e71121c95da3f79e6d2a96120163443b3ad1057505/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88", size = 140251, upload-time = "2024-10-09T07:39:16.995Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7d/0d/6f32255c1979653b448d3c709583557a4d24ff97ac4f3a5be156b2e6a210/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90", size = 148474, upload-time = "2024-10-09T07:39:18.021Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ac/a0/c1b5298de4670d997101fef95b97ac440e8c8d8b4efa5a4d1ef44af82f0d/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b", size = 151849, upload-time = "2024-10-09T07:39:19.243Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/04/4f/b3961ba0c664989ba63e30595a3ed0875d6790ff26671e2aae2fdc28a399/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d", size = 149781, upload-time = "2024-10-09T07:39:20.397Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d8/90/6af4cd042066a4adad58ae25648a12c09c879efa4849c705719ba1b23d8c/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482", size = 144970, upload-time = "2024-10-09T07:39:21.452Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cc/67/e5e7e0cbfefc4ca79025238b43cdf8a2037854195b37d6417f3d0895c4c2/charset_normalizer-3.4.0-cp313-cp313-win32.whl", hash = "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67", size = 94973, upload-time = "2024-10-09T07:39:22.509Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/65/97/fc9bbc54ee13d33dc54a7fcf17b26368b18505500fc01e228c27b5222d80/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b", size = 102308, upload-time = "2024-10-09T07:39:23.524Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl", hash = "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079", size = 49446, upload-time = "2024-10-09T07:40:19.383Z" },
 ]
 
 [[package]]
@@ -132,27 +132,27 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121, upload-time = "2023-08-17T17:29:11.868Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941, upload-time = "2023-08-17T17:29:10.08Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "durationpy"
 version = "0.9"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/31/e9/f49c4e7fccb77fa5c43c2480e09a857a78b41e7331a75e128ed5df45c56b/durationpy-0.9.tar.gz", hash = "sha256:fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a", size = 3186 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/31/e9/f49c4e7fccb77fa5c43c2480e09a857a78b41e7331a75e128ed5df45c56b/durationpy-0.9.tar.gz", hash = "sha256:fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a", size = 3186, upload-time = "2024-10-02T17:59:00.873Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4c/a3/ac312faeceffd2d8f86bc6dcb5c401188ba5a01bc88e69bed97578a0dfcd/durationpy-0.9-py3-none-any.whl", hash = "sha256:e65359a7af5cedad07fb77a2dd3f390f8eb0b74cb845589fa6c057086834dd38", size = 3461 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4c/a3/ac312faeceffd2d8f86bc6dcb5c401188ba5a01bc88e69bed97578a0dfcd/durationpy-0.9-py3-none-any.whl", hash = "sha256:e65359a7af5cedad07fb77a2dd3f390f8eb0b74cb845589fa6c057086834dd38", size = 3461, upload-time = "2024-10-02T17:58:59.349Z" },
 ]
 
 [[package]]
@@ -166,9 +166,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/28/c8/046abf3ea11ec9cc3ea6d95e235a51161039d4a558484a997df60f9c51e9/google_api_core-2.21.0.tar.gz", hash = "sha256:4a152fd11a9f774ea606388d423b68aa7e6d6a0ffe4c8266f74979613ec09f81", size = 159313 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/28/c8/046abf3ea11ec9cc3ea6d95e235a51161039d4a558484a997df60f9c51e9/google_api_core-2.21.0.tar.gz", hash = "sha256:4a152fd11a9f774ea606388d423b68aa7e6d6a0ffe4c8266f74979613ec09f81", size = 159313, upload-time = "2024-10-09T13:48:39.872Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl", hash = "sha256:6869eacb2a37720380ba5898312af79a4d30b8bca1548fb4093e0697dc4bdf5d", size = 156437 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl", hash = "sha256:6869eacb2a37720380ba5898312af79a4d30b8bca1548fb4093e0697dc4bdf5d", size = 156437, upload-time = "2024-10-09T13:48:37.671Z" },
 ]
 
 [[package]]
@@ -182,9 +182,9 @@ dependencies = [
     { name = "httplib2" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ff/36/a587319840f32c8a28b6700805ad18a70690f985538ea49e87e210118884/google_api_python_client-2.149.0.tar.gz", hash = "sha256:b9d68c6b14ec72580d66001bd33c5816b78e2134b93ccc5cf8f624516b561750", size = 11791789 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ff/36/a587319840f32c8a28b6700805ad18a70690f985538ea49e87e210118884/google_api_python_client-2.149.0.tar.gz", hash = "sha256:b9d68c6b14ec72580d66001bd33c5816b78e2134b93ccc5cf8f624516b561750", size = 11791789, upload-time = "2024-10-09T13:50:38.373Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e1/33/b2fa6a8d7ca786c07ab4ab671aaa8dd5abb32893636fc44f684c396470cc/google_api_python_client-2.149.0-py2.py3-none-any.whl", hash = "sha256:1a5232e9cfed8c201799d9327e4d44dc7ea7daa3c6e1627fca41aa201539c0da", size = 12299231 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e1/33/b2fa6a8d7ca786c07ab4ab671aaa8dd5abb32893636fc44f684c396470cc/google_api_python_client-2.149.0-py2.py3-none-any.whl", hash = "sha256:1a5232e9cfed8c201799d9327e4d44dc7ea7daa3c6e1627fca41aa201539c0da", size = 12299231, upload-time = "2024-10-09T13:50:34.715Z" },
 ]
 
 [[package]]
@@ -196,9 +196,9 @@ dependencies = [
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a1/37/c854a8b1b1020cf042db3d67577c6f84cd1e8ff6515e4f5498ae9e444ea5/google_auth-2.35.0.tar.gz", hash = "sha256:f4c64ed4e01e8e8b646ef34c018f8bf3338df0c8e37d8b3bba40e7f574a3278a", size = 267223 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a1/37/c854a8b1b1020cf042db3d67577c6f84cd1e8ff6515e4f5498ae9e444ea5/google_auth-2.35.0.tar.gz", hash = "sha256:f4c64ed4e01e8e8b646ef34c018f8bf3338df0c8e37d8b3bba40e7f574a3278a", size = 267223, upload-time = "2024-09-19T18:07:33.106Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl", hash = "sha256:25df55f327ef021de8be50bad0dfd4a916ad0de96da86cd05661c9297723ad3f", size = 208968 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl", hash = "sha256:25df55f327ef021de8be50bad0dfd4a916ad0de96da86cd05661c9297723ad3f", size = 208968, upload-time = "2024-09-19T18:07:31.412Z" },
 ]
 
 [[package]]
@@ -209,9 +209,9 @@ dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/56/be/217a598a818567b28e859ff087f347475c807a5649296fb5a817c58dacef/google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05", size = 10842 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/56/be/217a598a818567b28e859ff087f347475c807a5649296fb5a817c58dacef/google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05", size = 10842, upload-time = "2023-12-12T17:40:30.722Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/8a/fe34d2f3f9470a27b01c9e76226965863f153d5fbe276f83608562e49c04/google_auth_httplib2-0.2.0-py2.py3-none-any.whl", hash = "sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d", size = 9253 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/8a/fe34d2f3f9470a27b01c9e76226965863f153d5fbe276f83608562e49c04/google_auth_httplib2-0.2.0-py2.py3-none-any.whl", hash = "sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d", size = 9253, upload-time = "2023-12-12T17:40:13.055Z" },
 ]
 
 [[package]]
@@ -222,9 +222,9 @@ dependencies = [
     { name = "google-auth" },
     { name = "requests-oauthlib" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cc/0f/1772edb8d75ecf6280f1c7f51cbcebe274e8b17878b382f63738fd96cee5/google_auth_oauthlib-1.2.1.tar.gz", hash = "sha256:afd0cad092a2eaa53cd8e8298557d6de1034c6cb4a740500b5357b648af97263", size = 24970 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cc/0f/1772edb8d75ecf6280f1c7f51cbcebe274e8b17878b382f63738fd96cee5/google_auth_oauthlib-1.2.1.tar.gz", hash = "sha256:afd0cad092a2eaa53cd8e8298557d6de1034c6cb4a740500b5357b648af97263", size = 24970, upload-time = "2024-07-08T23:11:24.377Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1a/8e/22a28dfbd218033e4eeaf3a0533b2b54852b6530da0c0fe934f0cc494b29/google_auth_oauthlib-1.2.1-py2.py3-none-any.whl", hash = "sha256:2d58a27262d55aa1b87678c3ba7142a080098cbc2024f903c62355deb235d91f", size = 24930 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1a/8e/22a28dfbd218033e4eeaf3a0533b2b54852b6530da0c0fe934f0cc494b29/google_auth_oauthlib-1.2.1-py2.py3-none-any.whl", hash = "sha256:2d58a27262d55aa1b87678c3ba7142a080098cbc2024f903c62355deb235d91f", size = 24930, upload-time = "2024-07-08T23:11:23.038Z" },
 ]
 
 [[package]]
@@ -234,9 +234,9 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/53/3b/1599ceafa875ffb951480c8c74f4b77646a6b80e80970698f2aa93c216ce/googleapis_common_protos-1.65.0.tar.gz", hash = "sha256:334a29d07cddc3aa01dee4988f9afd9b2916ee2ff49d6b757155dc0d197852c0", size = 113657 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/53/3b/1599ceafa875ffb951480c8c74f4b77646a6b80e80970698f2aa93c216ce/googleapis_common_protos-1.65.0.tar.gz", hash = "sha256:334a29d07cddc3aa01dee4988f9afd9b2916ee2ff49d6b757155dc0d197852c0", size = 113657, upload-time = "2024-08-27T16:16:54.012Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ec/08/49bfe7cf737952cc1a9c43e80cc258ed45dad7f183c5b8276fc94cb3862d/googleapis_common_protos-1.65.0-py2.py3-none-any.whl", hash = "sha256:2972e6c496f435b92590fd54045060867f3fe9be2c82ab148fc8885035479a63", size = 220890 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ec/08/49bfe7cf737952cc1a9c43e80cc258ed45dad7f183c5b8276fc94cb3862d/googleapis_common_protos-1.65.0-py2.py3-none-any.whl", hash = "sha256:2972e6c496f435b92590fd54045060867f3fe9be2c82ab148fc8885035479a63", size = 220890, upload-time = "2024-08-27T16:16:52.675Z" },
 ]
 
 [[package]]
@@ -247,18 +247,18 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/48/76/d23fcdef5d8137513b64f7447849369983078e4025100d9149d5c8222e5a/gspread-6.1.4.tar.gz", hash = "sha256:b8eec27de7cadb338bb1b9f14a9be168372dee8965c0da32121816b5050ac1de", size = 78251 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/48/76/d23fcdef5d8137513b64f7447849369983078e4025100d9149d5c8222e5a/gspread-6.1.4.tar.gz", hash = "sha256:b8eec27de7cadb338bb1b9f14a9be168372dee8965c0da32121816b5050ac1de", size = 78251, upload-time = "2024-10-20T22:17:55.678Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/47/c7/28ad61476626d635288d1671326f6540145778a5f2fc9f907ad4d929ba90/gspread-6.1.4-py3-none-any.whl", hash = "sha256:c34781c426031a243ad154952b16f21ac56a5af90687885fbee3d1fba5280dcd", size = 57574 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/47/c7/28ad61476626d635288d1671326f6540145778a5f2fc9f907ad4d929ba90/gspread-6.1.4-py3-none-any.whl", hash = "sha256:c34781c426031a243ad154952b16f21ac56a5af90687885fbee3d1fba5280dcd", size = 57574, upload-time = "2024-10-20T22:17:53.906Z" },
 ]
 
 [[package]]
 name = "hjson"
 version = "3.1.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
 ]
 
 [[package]]
@@ -268,36 +268,36 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116, upload-time = "2023-03-21T22:29:37.214Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854, upload-time = "2023-03-21T22:29:35.683Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
 ]
 
 [[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
 ]
 
 [[package]]
@@ -310,54 +310,54 @@ dependencies = [
     { name = "placebo" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/fa/1b8328d2199520ef5a257f8a2e9315ed0b0194e353a152ca1959490dfbc8/kappa-0.6.0.tar.gz", hash = "sha256:4b5b372872f25d619e427e04282551048dc975a107385b076b3ffc6406a15833", size = 29680 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/fa/1b8328d2199520ef5a257f8a2e9315ed0b0194e353a152ca1959490dfbc8/kappa-0.6.0.tar.gz", hash = "sha256:4b5b372872f25d619e427e04282551048dc975a107385b076b3ffc6406a15833", size = 29680, upload-time = "2016-08-03T18:02:30.132Z" }
 
 [[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload-time = "2024-10-18T15:21:06.495Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload-time = "2024-10-18T15:21:07.295Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload-time = "2024-10-18T15:21:08.073Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload-time = "2024-10-18T15:21:09.318Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload-time = "2024-10-18T15:21:10.185Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload-time = "2024-10-18T15:21:11.005Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload-time = "2024-10-18T15:21:12.911Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
@@ -371,92 +371,92 @@ dependencies = [
     { name = "rsa" },
     { name = "six" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a6/7b/17244b1083e8e604bf154cf9b716aecd6388acd656dd01893d0d244c94d9/oauth2client-4.1.3.tar.gz", hash = "sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6", size = 155910 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a6/7b/17244b1083e8e604bf154cf9b716aecd6388acd656dd01893d0d244c94d9/oauth2client-4.1.3.tar.gz", hash = "sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6", size = 155910, upload-time = "2018-09-07T21:38:18.036Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl", hash = "sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac", size = 98206 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl", hash = "sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac", size = 98206, upload-time = "2018-09-07T21:38:16.742Z" },
 ]
 
 [[package]]
 name = "oauthlib"
 version = "3.2.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352, upload-time = "2022-10-17T20:04:27.471Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688, upload-time = "2022-10-17T20:04:24.037Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788, upload-time = "2024-06-09T23:19:24.956Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985, upload-time = "2024-06-09T23:19:21.909Z" },
 ]
 
 [[package]]
 name = "pillow"
 version = "10.4.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06", size = 46555059 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06", size = 46555059, upload-time = "2024-07-01T09:48:43.583Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a7/62/c9449f9c3043c37f73e7487ec4ef0c03eb9c9afc91a92b977a67b3c0bbc5/pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c", size = 3509265 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f4/5f/491dafc7bbf5a3cc1845dc0430872e8096eb9e2b6f8161509d124594ec2d/pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be", size = 3375655 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/73/d5/c4011a76f4207a3c151134cd22a1415741e42fa5ddecec7c0182887deb3d/pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3", size = 4340304 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ac/10/c67e20445a707f7a610699bba4fe050583b688d8cd2d202572b257f46600/pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6", size = 4452804 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a9/83/6523837906d1da2b269dee787e31df3b0acb12e3d08f024965a3e7f64665/pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe", size = 4365126 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ba/e5/8c68ff608a4203085158cff5cc2a3c534ec384536d9438c405ed6370d080/pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319", size = 4533541 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f4/7c/01b8dbdca5bc6785573f4cee96e2358b0918b7b2c7b60d8b6f3abf87a070/pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d", size = 4471616 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c8/57/2899b82394a35a0fbfd352e290945440e3b3785655a03365c0ca8279f351/pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696", size = 4600802 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4d/d7/a44f193d4c26e58ee5d2d9db3d4854b2cfb5b5e08d360a5e03fe987c0086/pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496", size = 2235213 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c1/d0/5866318eec2b801cdb8c82abf190c8343d8a1cd8bf5a0c17444a6f268291/pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91", size = 2554498 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d4/c8/310ac16ac2b97e902d9eb438688de0d961660a87703ad1561fd3dfbd2aa0/pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22", size = 2243219 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/05/cb/0353013dc30c02a8be34eb91d25e4e4cf594b59e5a55ea1128fde1e5f8ea/pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94", size = 3509350 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e7/cf/5c558a0f247e0bf9cec92bff9b46ae6474dd736f6d906315e60e4075f737/pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597", size = 3374980 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/84/48/6e394b86369a4eb68b8a1382c78dc092245af517385c086c5094e3b34428/pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80", size = 4343799 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3b/f3/a8c6c11fa84b59b9df0cd5694492da8c039a24cd159f0f6918690105c3be/pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca", size = 4459973 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7d/1b/c14b4197b80150fb64453585247e6fb2e1d93761fa0fa9cf63b102fde822/pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef", size = 4370054 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/55/77/40daddf677897a923d5d33329acd52a2144d54a9644f2a5422c028c6bf2d/pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a", size = 4539484 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/40/54/90de3e4256b1207300fb2b1d7168dd912a2fb4b2401e439ba23c2b2cabde/pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b", size = 4477375 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/24/1bfba52f44193860918ff7c93d03d95e3f8748ca1de3ceaf11157a14cf16/pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9", size = 4608773 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/55/04/5e6de6e6120451ec0c24516c41dbaf80cce1b6451f96561235ef2429da2e/pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42", size = 2235690 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/74/0a/d4ce3c44bca8635bd29a2eab5aa181b654a734a29b263ca8efe013beea98/pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a", size = 2554951 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b5/ca/184349ee40f2e92439be9b3502ae6cfc43ac4b50bc4fc6b3de7957563894/pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9", size = 2243427 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c3/00/706cebe7c2c12a6318aabe5d354836f54adff7156fd9e1bd6c89f4ba0e98/pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3", size = 3525685 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cf/76/f658cbfa49405e5ecbfb9ba42d07074ad9792031267e782d409fd8fe7c69/pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb", size = 3374883 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/46/2b/99c28c4379a85e65378211971c0b430d9c7234b1ec4d59b2668f6299e011/pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70", size = 4339837 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f1/74/b1ec314f624c0c43711fdf0d8076f82d9d802afd58f1d62c2a86878e8615/pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be", size = 4455562 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4a/2a/4b04157cb7b9c74372fa867096a1607e6fedad93a44deeff553ccd307868/pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0", size = 4366761 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ac/7b/8f1d815c1a6a268fe90481232c98dd0e5fa8c75e341a75f060037bd5ceae/pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc", size = 4536767 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e5/77/05fa64d1f45d12c22c314e7b97398ffb28ef2813a485465017b7978b3ce7/pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a", size = 4477989 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/12/63/b0397cfc2caae05c3fb2f4ed1b4fc4fc878f0243510a7a6034ca59726494/pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309", size = 4610255 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7b/f9/cfaa5082ca9bc4a6de66ffe1c12c2d90bf09c309a5f52b27759a596900e7/pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060", size = 2235603 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/01/6a/30ff0eef6e0c0e71e55ded56a38d4859bf9d3634a94a88743897b5f96936/pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea", size = 2554972 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/48/2c/2e0a52890f269435eee38b21c8218e102c621fe8d8df8b9dd06fabf879ba/pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d", size = 2243375 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a7/62/c9449f9c3043c37f73e7487ec4ef0c03eb9c9afc91a92b977a67b3c0bbc5/pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c", size = 3509265, upload-time = "2024-07-01T09:45:49.812Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f4/5f/491dafc7bbf5a3cc1845dc0430872e8096eb9e2b6f8161509d124594ec2d/pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be", size = 3375655, upload-time = "2024-07-01T09:45:52.462Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/73/d5/c4011a76f4207a3c151134cd22a1415741e42fa5ddecec7c0182887deb3d/pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3", size = 4340304, upload-time = "2024-07-01T09:45:55.006Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ac/10/c67e20445a707f7a610699bba4fe050583b688d8cd2d202572b257f46600/pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6", size = 4452804, upload-time = "2024-07-01T09:45:58.437Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a9/83/6523837906d1da2b269dee787e31df3b0acb12e3d08f024965a3e7f64665/pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe", size = 4365126, upload-time = "2024-07-01T09:46:00.713Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ba/e5/8c68ff608a4203085158cff5cc2a3c534ec384536d9438c405ed6370d080/pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319", size = 4533541, upload-time = "2024-07-01T09:46:03.235Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f4/7c/01b8dbdca5bc6785573f4cee96e2358b0918b7b2c7b60d8b6f3abf87a070/pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d", size = 4471616, upload-time = "2024-07-01T09:46:05.356Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c8/57/2899b82394a35a0fbfd352e290945440e3b3785655a03365c0ca8279f351/pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696", size = 4600802, upload-time = "2024-07-01T09:46:08.145Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4d/d7/a44f193d4c26e58ee5d2d9db3d4854b2cfb5b5e08d360a5e03fe987c0086/pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496", size = 2235213, upload-time = "2024-07-01T09:46:10.211Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c1/d0/5866318eec2b801cdb8c82abf190c8343d8a1cd8bf5a0c17444a6f268291/pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91", size = 2554498, upload-time = "2024-07-01T09:46:12.685Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d4/c8/310ac16ac2b97e902d9eb438688de0d961660a87703ad1561fd3dfbd2aa0/pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22", size = 2243219, upload-time = "2024-07-01T09:46:14.83Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/05/cb/0353013dc30c02a8be34eb91d25e4e4cf594b59e5a55ea1128fde1e5f8ea/pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94", size = 3509350, upload-time = "2024-07-01T09:46:17.177Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e7/cf/5c558a0f247e0bf9cec92bff9b46ae6474dd736f6d906315e60e4075f737/pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597", size = 3374980, upload-time = "2024-07-01T09:46:19.169Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/84/48/6e394b86369a4eb68b8a1382c78dc092245af517385c086c5094e3b34428/pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80", size = 4343799, upload-time = "2024-07-01T09:46:21.883Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3b/f3/a8c6c11fa84b59b9df0cd5694492da8c039a24cd159f0f6918690105c3be/pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca", size = 4459973, upload-time = "2024-07-01T09:46:24.321Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7d/1b/c14b4197b80150fb64453585247e6fb2e1d93761fa0fa9cf63b102fde822/pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef", size = 4370054, upload-time = "2024-07-01T09:46:26.825Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/55/77/40daddf677897a923d5d33329acd52a2144d54a9644f2a5422c028c6bf2d/pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a", size = 4539484, upload-time = "2024-07-01T09:46:29.355Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/40/54/90de3e4256b1207300fb2b1d7168dd912a2fb4b2401e439ba23c2b2cabde/pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b", size = 4477375, upload-time = "2024-07-01T09:46:31.756Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/24/1bfba52f44193860918ff7c93d03d95e3f8748ca1de3ceaf11157a14cf16/pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9", size = 4608773, upload-time = "2024-07-01T09:46:33.73Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/55/04/5e6de6e6120451ec0c24516c41dbaf80cce1b6451f96561235ef2429da2e/pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42", size = 2235690, upload-time = "2024-07-01T09:46:36.587Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/74/0a/d4ce3c44bca8635bd29a2eab5aa181b654a734a29b263ca8efe013beea98/pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a", size = 2554951, upload-time = "2024-07-01T09:46:38.777Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b5/ca/184349ee40f2e92439be9b3502ae6cfc43ac4b50bc4fc6b3de7957563894/pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9", size = 2243427, upload-time = "2024-07-01T09:46:43.15Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c3/00/706cebe7c2c12a6318aabe5d354836f54adff7156fd9e1bd6c89f4ba0e98/pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3", size = 3525685, upload-time = "2024-07-01T09:46:45.194Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cf/76/f658cbfa49405e5ecbfb9ba42d07074ad9792031267e782d409fd8fe7c69/pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb", size = 3374883, upload-time = "2024-07-01T09:46:47.331Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/46/2b/99c28c4379a85e65378211971c0b430d9c7234b1ec4d59b2668f6299e011/pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70", size = 4339837, upload-time = "2024-07-01T09:46:49.647Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f1/74/b1ec314f624c0c43711fdf0d8076f82d9d802afd58f1d62c2a86878e8615/pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be", size = 4455562, upload-time = "2024-07-01T09:46:51.811Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4a/2a/4b04157cb7b9c74372fa867096a1607e6fedad93a44deeff553ccd307868/pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0", size = 4366761, upload-time = "2024-07-01T09:46:53.961Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ac/7b/8f1d815c1a6a268fe90481232c98dd0e5fa8c75e341a75f060037bd5ceae/pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc", size = 4536767, upload-time = "2024-07-01T09:46:56.664Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e5/77/05fa64d1f45d12c22c314e7b97398ffb28ef2813a485465017b7978b3ce7/pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a", size = 4477989, upload-time = "2024-07-01T09:46:58.977Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/12/63/b0397cfc2caae05c3fb2f4ed1b4fc4fc878f0243510a7a6034ca59726494/pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309", size = 4610255, upload-time = "2024-07-01T09:47:01.189Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7b/f9/cfaa5082ca9bc4a6de66ffe1c12c2d90bf09c309a5f52b27759a596900e7/pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060", size = 2235603, upload-time = "2024-07-01T09:47:03.918Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/01/6a/30ff0eef6e0c0e71e55ded56a38d4859bf9d3634a94a88743897b5f96936/pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea", size = 2554972, upload-time = "2024-07-01T09:47:06.152Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/48/2c/2e0a52890f269435eee38b21c8218e102c621fe8d8df8b9dd06fabf879ba/pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d", size = 2243375, upload-time = "2024-07-01T09:47:09.065Z" },
 ]
 
 [[package]]
 name = "pip"
 version = "24.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4d/87/fb90046e096a03aeab235e139436b3fe804cdd447ed2093b0d70eba3f7f8/pip-24.2.tar.gz", hash = "sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8", size = 1922041 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4d/87/fb90046e096a03aeab235e139436b3fe804cdd447ed2093b0d70eba3f7f8/pip-24.2.tar.gz", hash = "sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8", size = 1922041, upload-time = "2024-07-28T22:40:55.693Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d4/55/90db48d85f7689ec6f81c0db0622d704306c5284850383c090e6c7195a5c/pip-24.2-py3-none-any.whl", hash = "sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2", size = 1815170 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d4/55/90db48d85f7689ec6f81c0db0622d704306c5284850383c090e6c7195a5c/pip-24.2-py3-none-any.whl", hash = "sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2", size = 1815170, upload-time = "2024-07-28T22:40:52.861Z" },
 ]
 
 [[package]]
 name = "placebo"
 version = "0.9.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/18/35/a60e29abebe274da55a62261a070c173bbb5faf1e6f3b35ac292d944d632/placebo-0.9.0.tar.gz", hash = "sha256:03157f8527bbc2965b71b88f4a139ef8038618b346787f20d63e3c5da541b047", size = 13555 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/18/35/a60e29abebe274da55a62261a070c173bbb5faf1e6f3b35ac292d944d632/placebo-0.9.0.tar.gz", hash = "sha256:03157f8527bbc2965b71b88f4a139ef8038618b346787f20d63e3c5da541b047", size = 13555, upload-time = "2019-02-16T17:15:26.88Z" }
 
 [[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
 ]
 
 [[package]]
@@ -466,32 +466,32 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7e/05/74417b2061e1bf1b82776037cad97094228fa1c1b6e82d08a78d3fb6ddb6/proto_plus-1.25.0.tar.gz", hash = "sha256:fbb17f57f7bd05a68b7707e745e26528b0b3c34e378db91eef93912c54982d91", size = 56124 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7e/05/74417b2061e1bf1b82776037cad97094228fa1c1b6e82d08a78d3fb6ddb6/proto_plus-1.25.0.tar.gz", hash = "sha256:fbb17f57f7bd05a68b7707e745e26528b0b3c34e378db91eef93912c54982d91", size = 56124, upload-time = "2024-10-23T15:03:39.579Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/dd/25/0b7cc838ae3d76d46539020ec39fc92bfc9acc29367e58fe912702c2a79e/proto_plus-1.25.0-py3-none-any.whl", hash = "sha256:c91fc4a65074ade8e458e95ef8bac34d4008daa7cce4a12d6707066fca648961", size = 50126 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/dd/25/0b7cc838ae3d76d46539020ec39fc92bfc9acc29367e58fe912702c2a79e/proto_plus-1.25.0-py3-none-any.whl", hash = "sha256:c91fc4a65074ade8e458e95ef8bac34d4008daa7cce4a12d6707066fca648961", size = 50126, upload-time = "2024-10-23T15:03:38.415Z" },
 ]
 
 [[package]]
 name = "protobuf"
 version = "5.28.3"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/74/6e/e69eb906fddcb38f8530a12f4b410699972ab7ced4e21524ece9d546ac27/protobuf-5.28.3.tar.gz", hash = "sha256:64badbc49180a5e401f373f9ce7ab1d18b63f7dd4a9cdc43c92b9f0b481cef7b", size = 422479 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/74/6e/e69eb906fddcb38f8530a12f4b410699972ab7ced4e21524ece9d546ac27/protobuf-5.28.3.tar.gz", hash = "sha256:64badbc49180a5e401f373f9ce7ab1d18b63f7dd4a9cdc43c92b9f0b481cef7b", size = 422479, upload-time = "2024-10-23T01:07:26.626Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d1/c5/05163fad52d7c43e124a545f1372d18266db36036377ad29de4271134a6a/protobuf-5.28.3-cp310-abi3-win32.whl", hash = "sha256:0c4eec6f987338617072592b97943fdbe30d019c56126493111cf24344c1cc24", size = 419624 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9c/4c/4563ebe001ff30dca9d7ed12e471fa098d9759712980cde1fd03a3a44fb7/protobuf-5.28.3-cp310-abi3-win_amd64.whl", hash = "sha256:91fba8f445723fcf400fdbe9ca796b19d3b1242cd873907979b9ed71e4afe868", size = 431464 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1c/f2/baf397f3dd1d3e4af7e3f5a0382b868d25ac068eefe1ebde05132333436c/protobuf-5.28.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a3f6857551e53ce35e60b403b8a27b0295f7d6eb63d10484f12bc6879c715687", size = 414743 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/85/50/cd61a358ba1601f40e7d38bcfba22e053f40ef2c50d55b55926aecc8fec7/protobuf-5.28.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:3fa2de6b8b29d12c61911505d893afe7320ce7ccba4df913e2971461fa36d584", size = 316511 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5d/ae/3257b09328c0b4e59535e497b0c7537d4954038bdd53a2f0d2f49d15a7c4/protobuf-5.28.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:712319fbdddb46f21abb66cd33cb9e491a5763b2febd8f228251add221981135", size = 316624 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ad/c3/2377c159e28ea89a91cf1ca223f827ae8deccb2c9c401e5ca233cd73002f/protobuf-5.28.3-py3-none-any.whl", hash = "sha256:cee1757663fa32a1ee673434fcf3bf24dd54763c79690201208bafec62f19eed", size = 169511 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d1/c5/05163fad52d7c43e124a545f1372d18266db36036377ad29de4271134a6a/protobuf-5.28.3-cp310-abi3-win32.whl", hash = "sha256:0c4eec6f987338617072592b97943fdbe30d019c56126493111cf24344c1cc24", size = 419624, upload-time = "2024-10-23T01:07:08.068Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9c/4c/4563ebe001ff30dca9d7ed12e471fa098d9759712980cde1fd03a3a44fb7/protobuf-5.28.3-cp310-abi3-win_amd64.whl", hash = "sha256:91fba8f445723fcf400fdbe9ca796b19d3b1242cd873907979b9ed71e4afe868", size = 431464, upload-time = "2024-10-23T01:07:11.819Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1c/f2/baf397f3dd1d3e4af7e3f5a0382b868d25ac068eefe1ebde05132333436c/protobuf-5.28.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a3f6857551e53ce35e60b403b8a27b0295f7d6eb63d10484f12bc6879c715687", size = 414743, upload-time = "2024-10-23T01:07:13.455Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/85/50/cd61a358ba1601f40e7d38bcfba22e053f40ef2c50d55b55926aecc8fec7/protobuf-5.28.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:3fa2de6b8b29d12c61911505d893afe7320ce7ccba4df913e2971461fa36d584", size = 316511, upload-time = "2024-10-23T01:07:14.51Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/5d/ae/3257b09328c0b4e59535e497b0c7537d4954038bdd53a2f0d2f49d15a7c4/protobuf-5.28.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:712319fbdddb46f21abb66cd33cb9e491a5763b2febd8f228251add221981135", size = 316624, upload-time = "2024-10-23T01:07:16.192Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ad/c3/2377c159e28ea89a91cf1ca223f827ae8deccb2c9c401e5ca233cd73002f/protobuf-5.28.3-py3-none-any.whl", hash = "sha256:cee1757663fa32a1ee673434fcf3bf24dd54763c79690201208bafec62f19eed", size = 169511, upload-time = "2024-10-23T01:07:24.738Z" },
 ]
 
 [[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
 ]
 
 [[package]]
@@ -501,18 +501,18 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "pyasn1" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1d/67/6afbf0d507f73c32d21084a79946bfcfca5fbc62a72057e9c23797a737c9/pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c", size = 310028 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1d/67/6afbf0d507f73c32d21084a79946bfcfca5fbc62a72057e9c23797a737c9/pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c", size = 310028, upload-time = "2024-09-10T22:42:08.349Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd", size = 181537 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd", size = 181537, upload-time = "2024-09-11T16:02:10.336Z" },
 ]
 
 [[package]]
 name = "pyparsing"
 version = "3.2.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8c/d5/e5aeee5387091148a19e1145f63606619cb5f20b83fccb63efae6474e7b2/pyparsing-3.2.0.tar.gz", hash = "sha256:cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c", size = 920984 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8c/d5/e5aeee5387091148a19e1145f63606619cb5f20b83fccb63efae6474e7b2/pyparsing-3.2.0.tar.gz", hash = "sha256:cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c", size = 920984, upload-time = "2024-10-13T10:01:16.046Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl", hash = "sha256:93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84", size = 106921 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl", hash = "sha256:93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84", size = 106921, upload-time = "2024-10-13T10:01:13.682Z" },
 ]
 
 [[package]]
@@ -525,9 +525,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3f/c0/238f25cb27495fdbaa5c48cef9886162e9df1f3d0e957fc8326d9c24fa2f/pytest-8.0.2.tar.gz", hash = "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd", size = 1396924 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3f/c0/238f25cb27495fdbaa5c48cef9886162e9df1f3d0e957fc8326d9c24fa2f/pytest-8.0.2.tar.gz", hash = "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd", size = 1396924, upload-time = "2024-02-24T22:21:30.762Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a7/ea/d0ab9595a0d4b2320483e634123171deaf50885e29d442180efcbf2ed0b2/pytest-8.0.2-py3-none-any.whl", hash = "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096", size = 333984 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a7/ea/d0ab9595a0d4b2320483e634123171deaf50885e29d442180efcbf2ed0b2/pytest-8.0.2-py3-none-any.whl", hash = "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096", size = 333984, upload-time = "2024-02-24T22:21:27.561Z" },
 ]
 
 [[package]]
@@ -537,18 +537,18 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
 ]
 
 [[package]]
@@ -558,44 +558,44 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "text-unidecode" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
 ]
 
 [[package]]
@@ -608,9 +608,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
 ]
 
 [[package]]
@@ -621,9 +621,9 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -633,34 +633,34 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "pyasn1" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21", size = 29711 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21", size = 29711, upload-time = "2022-07-20T10:28:36.115Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7", size = 34315 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7", size = 34315, upload-time = "2022-07-20T10:28:34.978Z" },
 ]
 
 [[package]]
 name = "ruff"
 version = "0.6.9"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/26/0d/6148a48dab5662ca1d5a93b7c0d13c03abd3cc7e2f35db08410e47cef15d/ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2", size = 3095355 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/26/0d/6148a48dab5662ca1d5a93b7c0d13c03abd3cc7e2f35db08410e47cef15d/ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2", size = 3095355, upload-time = "2024-10-04T13:40:28.594Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6e/8f/f7a0a0ef1818662efb32ed6df16078c95da7a0a3248d64c2410c1e27799f/ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd", size = 10440526 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8b/69/b179a5faf936a9e2ab45bb412a668e4661eded964ccfa19d533f29463ef6/ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec", size = 10034612 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c7/ef/fd1b4be979c579d191eeac37b5cfc0ec906de72c8bcd8595e2c81bb700c1/ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c", size = 9706197 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/29/61/b376d775deb5851cb48d893c568b511a6d3625ef2c129ad5698b64fb523c/ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e", size = 10751855 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/d7/def9e5f446d75b9a9c19b24231a3a658c075d79163b08582e56fa5dcfa38/ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577", size = 10200889 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6c/d6/7f34160818bcb6e84ce293a5966cba368d9112ff0289b273fbb689046047/ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829", size = 11038678 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/34/a40ff8ae62fb1b26fb8e6fa7e64bc0e0a834b47317880de22edd6bfb54fb/ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5", size = 11808682 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2e/6d/25a4386ae4009fc798bd10ba48c942d1b0b3e459b5403028f1214b6dd161/ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7", size = 11330446 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f7/f6/bdf891a9200d692c94ebcd06ae5a2fa5894e522f2c66c2a12dd5d8cb2654/ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f", size = 12483048 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a7/86/96f4252f41840e325b3fa6c48297e661abb9f564bd7dcc0572398c8daa42/ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa", size = 10936855 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/45/87/801a52d26c8dbf73424238e9908b9ceac430d903c8ef35eab1b44fcfa2bd/ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb", size = 10713007 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/27/6f7161d90320a389695e32b6ebdbfbedde28ccbf52451e4b723d7ce744ad/ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0", size = 10274594 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/52/dc311775e7b5f5b19831563cb1572ecce63e62681bccc609867711fae317/ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625", size = 10608024 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/98/b6/be0a1ddcbac65a30c985cf7224c4fce786ba2c51e7efeb5178fe410ed3cf/ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039", size = 10982085 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bb/a4/c84bc13d0b573cf7bb7d17b16d6d29f84267c92d79b2f478d4ce322e8e72/ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d", size = 8522088 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/74/be/fc352bd8ca40daae8740b54c1c3e905a7efe470d420a268cd62150248c91/ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117", size = 9359275 },
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3e/14/fd026bc74ded05e2351681545a5f626e78ef831f8edce064d61acd2e6ec7/ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93", size = 8679879 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6e/8f/f7a0a0ef1818662efb32ed6df16078c95da7a0a3248d64c2410c1e27799f/ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd", size = 10440526, upload-time = "2024-10-04T13:39:21.747Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/8b/69/b179a5faf936a9e2ab45bb412a668e4661eded964ccfa19d533f29463ef6/ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec", size = 10034612, upload-time = "2024-10-04T13:39:26.301Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c7/ef/fd1b4be979c579d191eeac37b5cfc0ec906de72c8bcd8595e2c81bb700c1/ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c", size = 9706197, upload-time = "2024-10-04T13:39:29.297Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/29/61/b376d775deb5851cb48d893c568b511a6d3625ef2c129ad5698b64fb523c/ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e", size = 10751855, upload-time = "2024-10-04T13:39:33.175Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/d7/def9e5f446d75b9a9c19b24231a3a658c075d79163b08582e56fa5dcfa38/ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577", size = 10200889, upload-time = "2024-10-04T13:39:36.867Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/6c/d6/7f34160818bcb6e84ce293a5966cba368d9112ff0289b273fbb689046047/ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829", size = 11038678, upload-time = "2024-10-04T13:39:40.428Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/13/34/a40ff8ae62fb1b26fb8e6fa7e64bc0e0a834b47317880de22edd6bfb54fb/ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5", size = 11808682, upload-time = "2024-10-04T13:39:52.141Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2e/6d/25a4386ae4009fc798bd10ba48c942d1b0b3e459b5403028f1214b6dd161/ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7", size = 11330446, upload-time = "2024-10-04T13:39:55.783Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/f7/f6/bdf891a9200d692c94ebcd06ae5a2fa5894e522f2c66c2a12dd5d8cb2654/ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f", size = 12483048, upload-time = "2024-10-04T13:39:58.845Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a7/86/96f4252f41840e325b3fa6c48297e661abb9f564bd7dcc0572398c8daa42/ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa", size = 10936855, upload-time = "2024-10-04T13:40:01.818Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/45/87/801a52d26c8dbf73424238e9908b9ceac430d903c8ef35eab1b44fcfa2bd/ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb", size = 10713007, upload-time = "2024-10-04T13:40:05.384Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/27/6f7161d90320a389695e32b6ebdbfbedde28ccbf52451e4b723d7ce744ad/ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0", size = 10274594, upload-time = "2024-10-04T13:40:08.801Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/00/52/dc311775e7b5f5b19831563cb1572ecce63e62681bccc609867711fae317/ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625", size = 10608024, upload-time = "2024-10-04T13:40:11.923Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/98/b6/be0a1ddcbac65a30c985cf7224c4fce786ba2c51e7efeb5178fe410ed3cf/ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039", size = 10982085, upload-time = "2024-10-04T13:40:15.539Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/bb/a4/c84bc13d0b573cf7bb7d17b16d6d29f84267c92d79b2f478d4ce322e8e72/ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d", size = 8522088, upload-time = "2024-10-04T13:40:19.168Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/74/be/fc352bd8ca40daae8740b54c1c3e905a7efe470d420a268cd62150248c91/ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117", size = 9359275, upload-time = "2024-10-04T13:40:22.852Z" },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3e/14/fd026bc74ded05e2351681545a5f626e78ef831f8edce064d61acd2e6ec7/ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93", size = 8679879, upload-time = "2024-10-04T13:40:25.797Z" },
 ]
 
 [[package]]
@@ -670,27 +670,27 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a0/a8/e0a98fd7bd874914f0608ef7c90ffde17e116aefad765021de0f012690a2/s3transfer-0.10.3.tar.gz", hash = "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c", size = 144591 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a0/a8/e0a98fd7bd874914f0608ef7c90ffde17e116aefad765021de0f012690a2/s3transfer-0.10.3.tar.gz", hash = "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c", size = 144591, upload-time = "2024-10-08T19:17:16.765Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e5/c0/b0fba8259b61c938c9733da9346b9f93e00881a9db22aafdd72f6ae0ec05/s3transfer-0.10.3-py3-none-any.whl", hash = "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d", size = 82625 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e5/c0/b0fba8259b61c938c9733da9346b9f93e00881a9db22aafdd72f6ae0ec05/s3transfer-0.10.3-py3-none-any.whl", hash = "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d", size = 82625, upload-time = "2024-10-08T19:17:14.904Z" },
 ]
 
 [[package]]
 name = "setuptools"
 version = "74.1.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3e/2c/f0a538a2f91ce633a78daaeb34cbfb93a54bd2132a6de1f6cec028eee6ef/setuptools-74.1.2.tar.gz", hash = "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6", size = 1356467 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/3e/2c/f0a538a2f91ce633a78daaeb34cbfb93a54bd2132a6de1f6cec028eee6ef/setuptools-74.1.2.tar.gz", hash = "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6", size = 1356467, upload-time = "2024-09-05T04:13:18.181Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cb/9c/9ad11ac06b97e55ada655f8a6bea9d1d3f06e120b178cd578d80e558191d/setuptools-74.1.2-py3-none-any.whl", hash = "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308", size = 1262071 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/cb/9c/9ad11ac06b97e55ada655f8a6bea9d1d3f06e120b178cd578d80e558191d/setuptools-74.1.2-py3-none-any.whl", hash = "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308", size = 1262071, upload-time = "2024-09-05T04:13:16.671Z" },
 ]
 
 [[package]]
 name = "six"
 version = "1.16.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041, upload-time = "2021-05-05T14:18:18.379Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053, upload-time = "2021-05-05T14:18:17.237Z" },
 ]
 
 [[package]]
@@ -701,18 +701,18 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/61/72/3d210136ec051ca8240af163c9b6960c18715797be20af31e63d3da5ee94/stripe-10.10.0.tar.gz", hash = "sha256:82351f9e1055c2161dc38c08a9bbf5c4b6c7f1caffcf911e999a7012369415e2", size = 1313050 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/61/72/3d210136ec051ca8240af163c9b6960c18715797be20af31e63d3da5ee94/stripe-10.10.0.tar.gz", hash = "sha256:82351f9e1055c2161dc38c08a9bbf5c4b6c7f1caffcf911e999a7012369415e2", size = 1313050, upload-time = "2024-09-05T21:02:54.641Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0d/fb/7c39404ed0ca4aaf93b2ae6fffe2de0bc4dc91f5f5b60f9813de93d5d3a8/stripe-10.10.0-py2.py3-none-any.whl", hash = "sha256:36ab5f75e4af790dd6888450d812f502357b3e699a93cd2f1a8fd0014a4b4fca", size = 1553756 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0d/fb/7c39404ed0ca4aaf93b2ae6fffe2de0bc4dc91f5f5b60f9813de93d5d3a8/stripe-10.10.0-py2.py3-none-any.whl", hash = "sha256:36ab5f75e4af790dd6888450d812f502357b3e699a93cd2f1a8fd0014a4b4fca", size = 1553756, upload-time = "2024-09-05T21:02:51.501Z" },
 ]
 
 [[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]
@@ -736,8 +736,10 @@ dev = [
     { name = "pillow" },
     { name = "pytest" },
     { name = "python-dotenv" },
-    { name = "ruff" },
     { name = "setuptools" },
+]
+lint = [
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -758,17 +760,17 @@ dev = [
     { name = "pillow", specifier = "==10.4.0" },
     { name = "pytest", specifier = "~=8.0.0" },
     { name = "python-dotenv", specifier = "~=1.0" },
-    { name = "ruff", specifier = "~=0.6.5" },
     { name = "setuptools", specifier = "==74.1.2" },
 ]
+lint = [{ name = "ruff", specifier = "~=0.6.5" }]
 
 [[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -778,9 +780,9 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504, upload-time = "2024-08-03T22:35:40.339Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", size = 78351 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", size = 78351, upload-time = "2024-08-03T22:35:36.644Z" },
 ]
 
 [[package]]
@@ -790,36 +792,36 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "cfn-flip" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c0/ea/8eed6b8e13bc27782694d03629d38f0ec3f41a6c4dbcc601e4343a4a0603/troposphere-4.8.3.tar.gz", hash = "sha256:22d64cc738a3a09ad4f001812049dc77e30a46a3716ba9bd53559ff89964e74d", size = 458582 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/c0/ea/8eed6b8e13bc27782694d03629d38f0ec3f41a6c4dbcc601e4343a4a0603/troposphere-4.8.3.tar.gz", hash = "sha256:22d64cc738a3a09ad4f001812049dc77e30a46a3716ba9bd53559ff89964e74d", size = 458582, upload-time = "2024-10-02T17:05:43.388Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2d/8a/f22f6ce85d700a6671e78da81514c138e6769d939a6789d2bc33fda59cf2/troposphere-4.8.3-py3-none-any.whl", hash = "sha256:9a474aad9eb8daa3459408b20fd2fa536358aceaaf96cafd86492e3a7c4f3a02", size = 530381 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/2d/8a/f22f6ce85d700a6671e78da81514c138e6769d939a6789d2bc33fda59cf2/troposphere-4.8.3-py3-none-any.whl", hash = "sha256:9a474aad9eb8daa3459408b20fd2fa536358aceaaf96cafd86492e3a7c4f3a02", size = 530381, upload-time = "2024-10-02T17:05:41.217Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
 ]
 
 [[package]]
 name = "uritemplate"
 version = "4.1.1"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d2/5a/4742fdba39cd02a56226815abfa72fe0aa81c33bed16ed045647d6000eba/uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0", size = 273898 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/d2/5a/4742fdba39cd02a56226815abfa72fe0aa81c33bed16ed045647d6000eba/uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0", size = 273898, upload-time = "2021-10-13T11:15:14.84Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/81/c0/7461b49cd25aeece13766f02ee576d1db528f1c37ce69aee300e075b485b/uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e", size = 10356 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/81/c0/7461b49cd25aeece13766f02ee576d1db528f1c37ce69aee300e075b485b/uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e", size = 10356, upload-time = "2021-10-13T11:15:12.316Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "1.26.20"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
 ]
 
 [[package]]
@@ -829,18 +831,18 @@ source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0f/e2/6dbcaab07560909ff8f654d3a2e5a60552d937c909455211b1b36d7101dc/werkzeug-3.0.4.tar.gz", hash = "sha256:34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306", size = 803966 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/0f/e2/6dbcaab07560909ff8f654d3a2e5a60552d937c909455211b1b36d7101dc/werkzeug-3.0.4.tar.gz", hash = "sha256:34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306", size = 803966, upload-time = "2024-08-21T19:50:36.316Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4b/84/997bbf7c2bf2dc3f09565c6d0b4959fefe5355c18c4096cfd26d83e0785b/werkzeug-3.0.4-py3-none-any.whl", hash = "sha256:02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c", size = 227554 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/4b/84/997bbf7c2bf2dc3f09565c6d0b4959fefe5355c18c4096cfd26d83e0785b/werkzeug-3.0.4-py3-none-any.whl", hash = "sha256:02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c", size = 227554, upload-time = "2024-08-21T19:50:34.534Z" },
 ]
 
 [[package]]
 name = "wheel"
 version = "0.44.0"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b7/a0/95e9e962c5fd9da11c1e28aa4c0d8210ab277b1ada951d2aee336b505813/wheel-0.44.0.tar.gz", hash = "sha256:a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49", size = 100733 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/b7/a0/95e9e962c5fd9da11c1e28aa4c0d8210ab277b1ada951d2aee336b505813/wheel-0.44.0.tar.gz", hash = "sha256:a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49", size = 100733, upload-time = "2024-08-04T14:55:12.29Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl", hash = "sha256:2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f", size = 67059 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl", hash = "sha256:2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f", size = 67059, upload-time = "2024-08-04T14:55:10.487Z" },
 ]
 
 [[package]]
@@ -867,16 +869,16 @@ dependencies = [
     { name = "werkzeug" },
     { name = "wheel" },
 ]
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/42/26/8a8cfebe0510d9a9cb9d29ad6ac2a38fe9d8104dd250186581f664a105cc/zappa-0.60.2.tar.gz", hash = "sha256:f20a07e8e447c954c50adafe93dd10c0c8261d70e7818bb2d4ba6023c6114542", size = 209147 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/42/26/8a8cfebe0510d9a9cb9d29ad6ac2a38fe9d8104dd250186581f664a105cc/zappa-0.60.2.tar.gz", hash = "sha256:f20a07e8e447c954c50adafe93dd10c0c8261d70e7818bb2d4ba6023c6114542", size = 209147, upload-time = "2025-06-02T09:47:23.14Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/11/dc/197934633fe04a161645da00ef2079879af4c0b4d0a472026960ec6a89b9/zappa-0.60.2-py3-none-any.whl", hash = "sha256:876b81210cc152b617b3ddd988a9376023d0b00e47a195d285d646198ef45563", size = 120540 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/11/dc/197934633fe04a161645da00ef2079879af4c0b4d0a472026960ec6a89b9/zappa-0.60.2-py3-none-any.whl", hash = "sha256:876b81210cc152b617b3ddd988a9376023d0b00e47a195d285d646198ef45563", size = 120540, upload-time = "2025-06-02T09:47:21.531Z" },
 ]
 
 [[package]]
 name = "zipp"
 version = "3.20.2"
 source = { registry = "https://pkgs.safetycli.com/repository/personal-5caaf/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199 }
+sdist = { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199, upload-time = "2024-09-13T13:44:16.101Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200 },
+    { url = "https://pkgs.safetycli.com/package/personal-5caaf/pypi/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200, upload-time = "2024-09-13T13:44:14.38Z" },
 ]


### PR DESCRIPTION
This pull request introduces two new scripts for generating counts of event participants by age group and gender, and refactors the project’s dependency configuration to better separate development and linting dependencies.

New scripts for event participant statistics:

* Added `scripts/get_poomsae_counts.py`, which connects to a DynamoDB table, retrieves competitor entries, and prints counts of participants in various poomsae events (individual, world class, pair, team) broken down by age group and gender.
* Added `scripts/get_sparring_counts.py`, which similarly retrieves competitor entries and prints counts for sparring events (color belts, grass roots, world class) by age group and gender, including combined totals.

Dependency management improvements:

* Updated `pyproject.toml` to use `[dependency-groups]` for organizing dependencies, moving linting tools (like `ruff`) into a separate `lint` group and keeping development dependencies in `dev`. This improves clarity and maintainability of dependency management.

closes #18 