### PR TITLE
Update GitHub Actions workflow to remove uv version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,6 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3
-      with:
-        # Install a specific version of uv.
-        version: "0.4.26"
 
     - name: Set up Python
       run: uv python install


### PR DESCRIPTION
We will use the latest unless we see issues.

closes #29 