### PR TITLE
Add script for breaking competition groups with export options

### DIFF
--- a/scripts/generate_all_badges.py
+++ b/scripts/generate_all_badges.py
@@ -114,7 +114,8 @@ def generate_badge(data, output_dir):
         badge_filename = f"{data['pk']['S']}_badge.jpg".replace(" ", "_")
 
         # Save the image for email attachment
-        badge.save(f"{output_dir}/{badge_filename}")
+        badge_path = os.path.join(output_dir, badge_filename)
+        badge.save(badge_path)
 
         # Save the image to an in-memory file for S3 Upload
         # badge_file = io.BytesIO()

--- a/scripts/generate_all_badges.py
+++ b/scripts/generate_all_badges.py
@@ -3,6 +3,7 @@
 # import io
 import os
 import boto3
+import argparse
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 from dotenv import load_dotenv
 
@@ -27,7 +28,7 @@ def get_entries():
     return items
 
 
-def generate_badge(data):
+def generate_badge(data, output_dir):
     """Generate an ID Badge using DB Data"""
 
     # S3 Client
@@ -113,7 +114,7 @@ def generate_badge(data):
         badge_filename = f"{data['pk']['S']}_badge.jpg".replace(" ", "_")
 
         # Save the image for email attachment
-        badge.save(f"output/{badge_filename}")
+        badge.save(f"{output_dir}/{badge_filename}")
 
         # Save the image to an in-memory file for S3 Upload
         # badge_file = io.BytesIO()
@@ -133,13 +134,26 @@ def generate_badge(data):
     return ret_msg
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate badges for competitors.")
+    parser.add_argument(
+        "--output-dir",
+        default="output/badges",
+        help="Directory for generated badge files. Defaults to output/badges/.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
     load_dotenv()
     entries = get_entries()
 
+    os.makedirs(args.output_dir, exist_ok=True)
+
     for entry in entries:
         print(f"Generating badge for {entry['full_name']['S']}")
-        generate_badge(entry)
+        generate_badge(entry, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_all_badges_okc.py
+++ b/scripts/generate_all_badges_okc.py
@@ -132,7 +132,7 @@ def generate_badge(data, output_dir):
         badge_filename = f"{data['pk']['S']}_badge.jpg".replace(" ", "_")
 
         # Save the image for email attachment
-        badge.save(f"{output_dir}/{badge_filename}")
+        badge.save(os.path.join(output_dir, badge_filename))
 
         ret_msg = f"Badge '{badge_filename}' generated"
 

--- a/scripts/generate_all_badges_okc.py
+++ b/scripts/generate_all_badges_okc.py
@@ -3,6 +3,7 @@
 # import io
 import os
 import boto3
+import argparse
 from PIL import Image, ImageDraw, ImageFont
 from dotenv import load_dotenv
 
@@ -45,7 +46,7 @@ def get_age_group(age):
     return age_group
 
 
-def generate_badge(data):
+def generate_badge(data, output_dir):
     """Generate an ID Badge using DB Data"""
 
     # Opening the template image as the main badge
@@ -131,7 +132,7 @@ def generate_badge(data):
         badge_filename = f"{data['pk']['S']}_badge.jpg".replace(" ", "_")
 
         # Save the image for email attachment
-        badge.save(f"output/{badge_filename}")
+        badge.save(f"{output_dir}/{badge_filename}")
 
         ret_msg = f"Badge '{badge_filename}' generated"
 
@@ -143,17 +144,30 @@ def generate_badge(data):
     return ret_msg
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate badges for competitors.")
+    parser.add_argument(
+        "--output-dir",
+        default="output/badges",
+        help="Directory for generated badge files. Defaults to output/badges/.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
     load_dotenv()
     entries = get_entries()
     # entries = [
     #     {'poomsae_form': {'S': ''}, 'coach': {'S': 'Master Jung'}, 'pair_poomsae_form': {'S': ''}, 'team_poomsae_form': {'S': ''}, 'full_name': {'S': 'Josiah Salazar'}, 'email': {'S': 'requiredcrio_ministries@hotmail.com'}, 'gender': {'S': 'male'}, 'weight': {'N': '60'}, 'reg_type': {'S': 'competitor'}, 'school': {'S': "Tiger Jung's TKD"}, 'birthdate': {'S': '2016-07-06'}, 'events': {'S': 'breaking,poomsae,world-class poomsae,sparring-wc,little_tiger,family poomsae,team poomsae,sparring-gr'}, 'height': {'N': '48'}, 'payment': {'S': 'pi_3S1E1hGXHNyjORpV1X0hUD3r'}, 'beltRank': {'S': 'yellow'}, 'parent': {'S': 'Rebekah Salazar'}, 'medical_form': {'M': {...}}, 'pk': {'S': "Tiger_Jung's_TKD-competitor-Josiah_Salazar"}, 'phone': {'S': '918-658-5576'}, 'age': {'N': '9'}, 'family_poomsae_form': {'S': ''}}
     # ]
 
+    os.makedirs(args.output_dir, exist_ok=True)
+
     for entry in entries:
         print(f"Generating badge for {entry['full_name']['S']}")
 
-        generate_badge(entry)
+        generate_badge(entry, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_breaking_schedule.py
+++ b/scripts/generate_breaking_schedule.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python
+
+import argparse
+import csv
+import json
+import math
+import os
+from dataclasses import dataclass, field
+
+import boto3
+from dotenv import load_dotenv
+
+script_path = os.path.abspath(__file__)
+script_directory = os.path.dirname(script_path)
+parent_directory = os.path.dirname(script_directory)
+os.chdir(parent_directory)
+
+AGE_GROUP_ORDER = ["dragon", "tiger", "youth", "cadet", "junior", "senior", "ultra"]
+AGE_GROUPS = {
+    "dragon": [4, 5, 6, 7],
+    "tiger": [8, 9],
+    "youth": [10, 11],
+    "cadet": [12, 13, 14],
+    "junior": [15, 16],
+    "senior": list(range(17, 33)),
+    "ultra": list(range(33, 100)),
+}
+
+BELT_ORDER = ["yellow", "orange", "green", "blue", "red", "brown", "black"]
+
+
+@dataclass
+class Competitor:
+    name: str
+    school: str
+    gender: str
+    age: int
+    weight: float
+    belt_rank: str
+    age_group: str
+    raw: dict
+
+
+@dataclass
+class Group:
+    gender: str
+    age_group: str
+    members: list[Competitor] = field(default_factory=list)
+
+
+def get_entries():
+    dynamodb = boto3.client("dynamodb")
+    table_name = os.getenv("DB_TABLE")
+    print(f"Getting entries from {table_name}")
+
+    items = []
+    last_evaluated_key = None
+    while True:
+        kwargs = {
+            "TableName": table_name,
+            "FilterExpression": "reg_type = :competitor",
+            "ExpressionAttributeValues": {
+                ":competitor": {
+                    "S": "competitor",
+                },
+            },
+        }
+        if last_evaluated_key:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+
+        response = dynamodb.scan(**kwargs)
+        items.extend(response.get("Items", []))
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
+    return items
+
+
+def get_age_group(age: int) -> str:
+    return next((group for group, ages in AGE_GROUPS.items() if age in ages), "ultra")
+
+
+def normalize_gender(gender: str) -> str:
+    gender = (gender or "").strip().lower()
+    if gender.startswith("m"):
+        return "male"
+    if gender.startswith("f"):
+        return "female"
+    return "unknown"
+
+
+def normalize_belt_rank(belt_rank: str) -> str:
+    belt_rank = (belt_rank or "").strip().lower()
+    if "black" in belt_rank:
+        return "black"
+    for belt in BELT_ORDER:
+        if belt in belt_rank:
+            return belt
+    return belt_rank
+
+
+def is_breaking_competitor(events: str) -> bool:
+    return "breaking" in {event.strip() for event in events.split(",")}
+
+
+def parse_competitors(entries: list[dict]) -> list[Competitor]:
+    competitors = []
+    for entry in entries:
+        events = entry.get("events", {}).get("S", "")
+        if not is_breaking_competitor(events):
+            continue
+
+        age = int(entry.get("age", {}).get("N", 0))
+        weight = float(entry.get("weight", {}).get("N", 0))
+        gender = normalize_gender(entry.get("gender", {}).get("S", "unknown"))
+        school = entry.get("school", {}).get("S", "Unknown School")
+        name = entry.get("full_name", {}).get("S", "Unknown Competitor")
+        belt_rank = normalize_belt_rank(entry.get("beltRank", {}).get("S", ""))
+        age_group = get_age_group(age)
+
+        competitors.append(
+            Competitor(
+                name=name,
+                school=school,
+                gender=gender,
+                age=age,
+                weight=weight,
+                belt_rank=belt_rank,
+                age_group=age_group,
+                raw=entry,
+            )
+        )
+
+    return competitors
+
+
+def belt_rank_index(belt_rank: str) -> int:
+    try:
+        return BELT_ORDER.index(belt_rank)
+    except ValueError:
+        return len(BELT_ORDER)
+
+
+def group_size_plan(count: int) -> list[int]:
+    if count <= 0:
+        return []
+    if count <= 4:
+        return [count]
+
+    groups = math.ceil(count / 4)
+    sizes = [count // groups] * groups
+
+    for index in range(count % groups):
+        sizes[index] += 1
+
+    return sizes
+
+
+def _assign_school_diverse(entries: list[Competitor], size_plan: list[int]) -> list[list[Competitor]]:
+    """Fill groups according to size_plan, minimising same-school pairings."""
+    groups: list[list[Competitor]] = [[] for _ in size_plan]
+    max_sizes = list(size_plan)
+
+    for competitor in entries:
+        candidates = [index for index, group in enumerate(groups) if len(group) < max_sizes[index]]
+        best_index = min(
+            candidates,
+            key=lambda index: (
+                sum(1 for member in groups[index] if member.school == competitor.school),
+                len(groups[index]),
+            ),
+        )
+        groups[best_index].append(competitor)
+
+    return groups
+
+
+def split_by_belt_weight_and_school(entries: list[Competitor]) -> list[list[Competitor]]:
+    """Group competitors by belt rank, merge singletons into adjacent belt groups, then split
+    into groups of 2-4 with school-diversity optimisation within each belt cluster."""
+
+    # Build per-belt buckets sorted by weight
+    belt_buckets: dict[str, list[Competitor]] = {}
+    for competitor in entries:
+        belt_buckets.setdefault(competitor.belt_rank, []).append(competitor)
+    for key in belt_buckets:
+        belt_buckets[key].sort(key=lambda c: c.weight)
+
+    # Order buckets by belt rank (unknown belts go last)
+    ordered_keys = sorted(belt_buckets.keys(), key=belt_rank_index)
+
+    # Start with one cluster per belt rank, then merge singletons into nearest neighbor
+    clusters: list[list[str]] = [[key] for key in ordered_keys]
+
+    changed = True
+    while changed:
+        changed = False
+        new_clusters: list[list[str]] = []
+        i = 0
+        while i < len(clusters):
+            cluster = clusters[i]
+            cluster_size = sum(len(belt_buckets[k]) for k in cluster)
+            if cluster_size == 1:
+                if i + 1 < len(clusters):
+                    # Merge with next (higher belt)
+                    new_clusters.append(cluster + clusters[i + 1])
+                    i += 2
+                    changed = True
+                elif new_clusters:
+                    # Fall back: merge with previous cluster
+                    new_clusters[-1] = new_clusters[-1] + cluster
+                    i += 1
+                    changed = True
+                else:
+                    new_clusters.append(cluster)
+                    i += 1
+            else:
+                new_clusters.append(cluster)
+                i += 1
+        clusters = new_clusters
+
+    # Split each cluster into groups of 2-4 with school diversity
+    all_groups: list[list[Competitor]] = []
+    for cluster in clusters:
+        cluster_entries: list[Competitor] = []
+        for key in cluster:
+            cluster_entries.extend(belt_buckets[key])
+        size_plan = group_size_plan(len(cluster_entries))
+        if not size_plan:
+            continue
+        all_groups.extend(_assign_school_diverse(cluster_entries, size_plan))
+
+    return all_groups
+
+
+def generate_groups(competitors: list[Competitor]) -> list[Group]:
+    groups = []
+
+    for gender in ["female", "male", "unknown"]:
+        gender_competitors = [c for c in competitors if c.gender == gender]
+        if not gender_competitors:
+            continue
+
+        by_age_group: dict[str, list[Competitor]] = {age_group: [] for age_group in AGE_GROUP_ORDER}
+        for competitor in gender_competitors:
+            by_age_group[competitor.age_group].append(competitor)
+
+        for age_group in AGE_GROUP_ORDER:
+            entries = by_age_group[age_group]
+            if not entries:
+                continue
+
+            for members in split_by_belt_weight_and_school(entries):
+                groups.append(Group(gender=gender, age_group=age_group, members=members))
+
+    return groups
+
+
+def print_groups(groups: list[Group]) -> None:
+    gender_order = {"female": 0, "male": 1, "unknown": 2}
+
+    groups = sorted(
+        groups,
+        key=lambda group: (
+            gender_order.get(group.gender, 99),
+            AGE_GROUP_ORDER.index(group.age_group),
+            len(group.members),
+        ),
+    )
+
+    if not groups:
+        print("No breaking competitors found.")
+        return
+
+    print("Breaking Groups (target size: 2-4 competitors)")
+    print("=" * 80)
+
+    for index, group in enumerate(groups, start=1):
+        print(f"Group {index:02d} | gender={group.gender} | age={group.age_group} | size={len(group.members)}")
+
+        for member in sorted(group.members, key=lambda c: (belt_rank_index(c.belt_rank), c.weight)):
+            print(
+                f"  - {member.name} | {member.school} | age={member.age} | "
+                f"belt={member.belt_rank} | weight={member.weight:.1f}"
+            )
+
+        if len(group.members) < 2:
+            print("  ! Needs manual merge (single competitor group)")
+
+        schools = [member.school for member in group.members]
+        duplicates = {school for school in schools if schools.count(school) > 1}
+        if duplicates:
+            print(f"  ! Same-school matchup present: {', '.join(sorted(duplicates))}")
+
+        print()
+
+
+def groups_to_rows(groups: list[Group]) -> list[dict]:
+    rows = []
+    for group_index, group in enumerate(groups, start=1):
+        for competitor in sorted(group.members, key=lambda m: (belt_rank_index(m.belt_rank), m.weight)):
+            rows.append(
+                {
+                    "group_number": group_index,
+                    "gender": group.gender,
+                    "age_group": group.age_group,
+                    "group_size": len(group.members),
+                    "competitor_name": competitor.name,
+                    "school": competitor.school,
+                    "age": competitor.age,
+                    "belt_rank": competitor.belt_rank,
+                    "weight": competitor.weight,
+                }
+            )
+    return rows
+
+
+def write_csv(groups: list[Group], output_path: str) -> None:
+    rows = groups_to_rows(groups)
+    fieldnames = [
+        "group_number",
+        "gender",
+        "age_group",
+        "group_size",
+        "competitor_name",
+        "school",
+        "age",
+        "belt_rank",
+        "weight",
+    ]
+
+    with open(output_path, "w", newline="", encoding="utf-8") as file_handle:
+        writer = csv.DictWriter(file_handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(groups: list[Group], output_path: str) -> None:
+    rows = groups_to_rows(groups)
+    with open(output_path, "w", encoding="utf-8") as file_handle:
+        json.dump(rows, file_handle, indent=2)
+
+
+def export_groups(groups: list[Group], output_format: str, output_dir: str = "output") -> list[str]:
+    os.makedirs(output_dir, exist_ok=True)
+    written_files = []
+
+    if output_format in {"csv", "both"}:
+        csv_path = os.path.join(output_dir, "breaking_groups.csv")
+        write_csv(groups, csv_path)
+        written_files.append(csv_path)
+
+    if output_format in {"json", "both"}:
+        json_path = os.path.join(output_dir, "breaking_groups.json")
+        write_json(groups, json_path)
+        written_files.append(json_path)
+
+    return written_files
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate 2-4 person breaking groups.")
+    parser.add_argument(
+        "--output-format",
+        choices=["csv", "json", "both"],
+        default="csv",
+        help="Output format for saved group data. Defaults to csv.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        help="Directory for generated schedule files. Defaults to output/.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    load_dotenv()
+    entries = get_entries()
+    competitors = parse_competitors(entries)
+    groups = generate_groups(competitors)
+    print_groups(groups)
+    written_files = export_groups(groups, args.output_format, args.output_dir)
+    print("Saved group data to:")
+    for file_path in written_files:
+        print(f"  - {file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_breaking_schedule.py
+++ b/scripts/generate_breaking_schedule.py
@@ -369,8 +369,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output-dir",
-        default="output",
-        help="Directory for generated schedule files. Defaults to output/.",
+        default="output/schedules",
+        help="Directory for generated schedule files. Defaults to output/schedules/.",
     )
     return parser.parse_args()
 

--- a/scripts/generate_breaking_schedule.py
+++ b/scripts/generate_breaking_schedule.py
@@ -342,7 +342,7 @@ def write_json(groups: list[Group], output_path: str) -> None:
         json.dump(rows, file_handle, indent=2)
 
 
-def export_groups(groups: list[Group], output_format: str, output_dir: str = "output") -> list[str]:
+def export_groups(groups: list[Group], output_format: str, output_dir: str = "output/schedules") -> list[str]:
     os.makedirs(output_dir, exist_ok=True)
     written_files = []
 

--- a/scripts/generate_poomsae_schedule.py
+++ b/scripts/generate_poomsae_schedule.py
@@ -485,12 +485,12 @@ def export_report(rows: list[dict], output_format: str, output_dir: str) -> list
     written_files = []
 
     if output_format in {"csv", "both"}:
-        csv_path = os.path.join(output_dir, "poomsae_schedule_v2.csv")
+        csv_path = os.path.join(output_dir, "poomsae_groups.csv")
         write_csv(rows, csv_path)
         written_files.append(csv_path)
 
     if output_format in {"json", "both"}:
-        json_path = os.path.join(output_dir, "poomsae_schedule_v2.json")
+        json_path = os.path.join(output_dir, "poomsae_groups.json")
         write_json(rows, json_path)
         written_files.append(json_path)
 

--- a/scripts/generate_poomsae_schedule.py
+++ b/scripts/generate_poomsae_schedule.py
@@ -507,8 +507,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output-dir",
-        default="output",
-        help="Directory for generated schedule files. Defaults to output/.",
+        default="output/schedules",
+        help="Directory for generated schedule files. Defaults to output/schedules/.",
     )
     return parser.parse_args()
 

--- a/scripts/generate_sparring_schedule.py
+++ b/scripts/generate_sparring_schedule.py
@@ -493,8 +493,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--output-dir",
-        default="output",
-        help="Directory for generated schedule files. Defaults to output/.",
+        default="output/schedules",
+        help="Directory for generated schedule files. Defaults to output/schedules/.",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
This pull request introduces several improvements to the badge generation and scheduling scripts, focusing on flexibility, usability, and consistency. The most significant changes include parameterizing output directories for badge generation, adding a new script for breaking schedule generation, and updating default output paths for schedule files.

**Badge Generation Improvements:**
- Both `generate_all_badges.py` and `generate_all_badges_okc.py` now accept an `--output-dir` argument, allowing users to specify where badge images are saved. The default output directory is changed to `output/badges`, and the code ensures this directory is created if it doesn't exist.

**New Breaking Schedule Script:**
- A new script, `generate_breaking_schedule.py`, is added to automate grouping of breaking competitors into 2-4 person groups, optimizing for age, belt rank, weight, gender, and minimizing same-school matchups. The script supports both CSV and JSON output formats and allows users to specify the output directory.

**Schedule Output Directory and Naming Consistency:**
- The default output directory for generated schedules in the poomsae and sparring schedule scripts is updated from `output` to `output/schedules` for better organization. 
- Output filenames for poomsae group schedules are standardized to `poomsae_groups.csv` and `poomsae_groups.json`.